### PR TITLE
Allow the Bulgarian Fatherland Front to be Dealt Final Blow if its factions are integrated or at max loyalty

### DIFF
--- a/common/decisions/BUL.txt
+++ b/common/decisions/BUL.txt
@@ -5634,8 +5634,11 @@ BUL_the_fatherland_front_dec_cat = {
 					has_country_flag = BUL_zveno_joined_ff_flag
 				}
 				custom_trigger_tooltip = {
-					tooltip = BUL_ff_deal_the_final_blow_zveno_pop_tt
-					check_variable = { BUL_zveno_popularity = 5 compare = less_than }
+					tooltip = SPT_BUL_ff_deal_the_final_blow_zveno_pop_tt
+					OR = {
+						check_variable = { BUL_zveno_popularity < 5 }
+						check_variable = { BUL_zveno_loyalty > 95 }
+					}
 				}	
 			}
 			if = {
@@ -5643,8 +5646,11 @@ BUL_the_fatherland_front_dec_cat = {
 					has_country_flag = BUL_bs_joined_ff_flag
 				}
 				custom_trigger_tooltip = {
-					tooltip = BUL_ff_deal_the_final_blow_bs_pop_tt
-					check_variable = { BUL_bs_popularity = 5 compare = less_than }
+					tooltip = SPT_BUL_ff_deal_the_final_blow_bs_pop_tt
+					OR = {
+					check_variable = { BUL_bs_popularity < 5 }
+						check_variable = { BUL_bs_loyalty > 95 }
+					}
 				}
 			}
 			if = {
@@ -5652,8 +5658,11 @@ BUL_the_fatherland_front_dec_cat = {
 					has_country_flag = BUL_bzns_joined_ff_flag
 				}
 				custom_trigger_tooltip = {
-					tooltip = BUL_ff_deal_the_final_blow_bzns_pop_tt
-					check_variable = { BUL_bzns_popularity = 5 compare = less_than }
+					tooltip = SPT_BUL_ff_deal_the_final_blow_bzns_pop_tt
+					OR = {
+						check_variable = { BUL_bzns_popularity < 5 }
+						check_variable = { BUL_bzns_loyalty > 95 }
+					}
 				}
 			}
 		}
@@ -5680,6 +5689,11 @@ BUL_the_fatherland_front_dec_cat = {
 			if = {
 				limit = {
 					has_country_flag = BUL_zveno_joined_ff_flag
+					NOT = {
+						has_country_flag = BUL_zveno_integrated_flag
+						has_country_flag = BUL_zveno_destroyed_flag
+						check_variable = { BUL_zveno_loyalty > 95 }
+					}
 				}
 				set_country_flag = BUL_zveno_destroyed_flag
 				custom_effect_tooltip = BUL_ff_deal_the_final_blow_zveno_destroyed_tt
@@ -5687,6 +5701,11 @@ BUL_the_fatherland_front_dec_cat = {
 			if = {
 				limit = {
 					has_country_flag = BUL_bs_joined_ff_flag
+					NOT = {
+						has_country_flag = BUL_bs_integrated_flag
+						has_country_flag = BUL_bs_destroyed_flag
+						check_variable = { BUL_bs_loyalty > 95 }
+					}
 				}
 				set_country_flag = BUL_bs_destroyed_flag
 				custom_effect_tooltip = BUL_ff_deal_the_final_blow_bs_destroyed_tt
@@ -5694,6 +5713,11 @@ BUL_the_fatherland_front_dec_cat = {
 			if = {
 				limit = {
 					has_country_flag = BUL_bzns_joined_ff_flag
+					NOT = {
+						has_country_flag = BUL_bzns_integrated_flag
+						has_country_flag = BUL_bzns_destroyed_flag
+						check_variable = { BUL_bzns_loyalty > 95 }
+					}
 				}
 				set_country_flag = BUL_bzns_destroyed_flag
 				custom_effect_tooltip = BUL_ff_deal_the_final_blow_bzns_destroyed_tt

--- a/localisation/english/spt_tooltips_l_english.yml
+++ b/localisation/english/spt_tooltips_l_english.yml
@@ -160,3 +160,7 @@ SPT_CW_auto_complete_tt:0 "§LThis focus will auto-complete once §CEngland§L h
 SPT_CW_marine_doctrine_boost:0 "Marine Specialization"
 SPT_CW_para_doctrine_boost:0 "Paratrooper Specialization"
 SPT_CW_mount_doctrine_boost:0 "Mountaineer Specialization"
+
+SPT_BUL_ff_deal_the_final_blow_zveno_pop_tt:0 "[GetZvenoName] Faction Popularity is §Y0§! or Loyalty is §Y100§!."
+SPT_BUL_ff_deal_the_final_blow_bs_pop_tt:0 "[GetBsName] Faction Popularity is §Y0§! or Loyalty is §Y100§!."
+SPT_BUL_ff_deal_the_final_blow_bzns_pop_tt:0 "[GetBznsName] Faction Popularity is §Y0§! or Loyalty is §Y100§!."


### PR DESCRIPTION
Following the in-game advice to approach _or_ integrate factions can lead to a soft-lock during Fatherland Front if a faction is integrated after already joining the FF. This change allows integrated factions to satisfy the conditions for Deal the Final Blow (and also excludes them from being destroyed by that decision).