### PR TITLE
Bulgarian civil war rework

### DIFF
--- a/common/ideas/spt_bulgaria.txt
+++ b/common/ideas/spt_bulgaria.txt
@@ -1,0 +1,19 @@
+ideas = {
+	country = {
+		SPT_BUL_communist_party = {
+			picture = ROM_king_carol_ii_hedonist
+
+			allowed = {
+				original_tag = BUL
+			}
+			
+			removal_cost = -1
+			
+			modifier = {
+				stability_weekly = -0.002
+				political_power_factor = -0.25
+				communism_drift = 0.15
+			}
+		}
+	}
+}

--- a/common/on_actions/06_bftb_on_actions.txt
+++ b/common/on_actions/06_bftb_on_actions.txt
@@ -1,0 +1,1692 @@
+on_actions = { 
+# ROOT is capitulated country, FROM is winner
+	on_capitulation = {
+		effect = {
+			if = {
+				limit = {
+					GRE = { has_country_flag = GRE_megali_idea_approved }
+					original_tag = TUR
+					has_war_with = GRE
+				}
+				GRE = { country_event = { id = bftb_greece.208 days = 0 } }
+			}
+		}
+	}
+	on_war = {
+		effect = {
+			if = {
+				limit = {
+					original_tag = GRE
+					GRE = { has_idea = GRE_booming_tourism }
+				}
+				GRE = { remove_ideas = GRE_booming_tourism }
+			}
+		}
+		effect = {
+			if = {
+				limit = {
+					original_tag = TUR
+					TUR = { 
+						AND = {
+							has_completed_focus = TUR_invite_german_officers_to_izmir
+							NOT = { has_completed_focus = TUR_integrate_german_officers_into_the_army }
+						}
+						has_war_with = GER
+						has_unit_leader = 75
+					}
+				}
+				TUR = { 
+					remove_ideas = TUR_german_advisors 
+					GER_hans_von_luck = { set_nationality = GER }
+				} 
+			}
+			if = {
+				limit = {
+					original_tag = TUR
+					TUR = { 
+						AND = {
+							has_completed_focus = TUR_invite_german_officers_to_izmir
+							NOT = { has_completed_focus = TUR_integrate_german_officers_into_the_army }
+						}
+						has_war_with = GER
+						has_unit_leader = 76
+					}
+				}
+				TUR = {
+					GER_wilhelm_ritter_von_thoma = { set_nationality = GER }
+				} 
+			}
+			if = {
+				limit = {
+					original_tag = TUR
+					TUR = { 
+						has_completed_focus = TUR_the_italo_turkish_naval_academy
+						has_war_with = ITA
+						has_unit_leader = 77
+					}
+				}
+				TUR = { 
+					remove_ideas = TUR_the_antalya_naval_academy
+					ITA_ferdinando_umberto_filippo_adalberto = { set_nationality = ITA }
+				} 
+			}
+			if = {
+				limit = {
+					original_tag = TUR
+					TUR = { 
+						has_country_flag = TUR_the_chester_concession_flag
+						has_war_with = USA
+					}
+				}
+				TUR = {
+					add_offsite_building = {  type = industrial_complex level = -3 }
+				}
+			}
+		}
+	}
+	#ROOT is new controller #FROM is old controller #FROM.FROM is state ID
+	on_state_control_changed = {
+		effect = {
+			if = {
+				limit = {
+					FROM.FROM = { state = 341 }
+					ROOT = { has_country_flag = BOSPHORUS_STRAIT_BLOCKED_FOR_COUNTRY }
+				}
+				GRE = { clr_country_flag = BOSPHORUS_STRAIT_BLOCKED_FOR_COUNTRY }
+				SOV = { clr_country_flag = BOSPHORUS_STRAIT_BLOCKED_FOR_COUNTRY }
+			}
+		}
+
+		effect = { #Check for Turkish state modifiers for non-Turkish occupiers
+			if = {
+				limit = {
+					FROM = { original_tag = TUR }
+					ROOT = { NOT = { tag = TUR } }
+					FROM.FROM = { 
+						TUR_has_turkish_state_modifier = yes 
+					}
+				}
+				FROM.FROM = { 
+					TUR_remove_state_modifier_effect = yes
+				}
+			}
+		}
+		effect = { #Check for lost Turkish state modifiers
+			if = {
+				limit = {
+					FROM.FROM = { 
+						AND = { 
+							is_owned_and_controlled_by = TUR
+							TUR_has_former_turkish_state_modifier = yes
+						}
+					}
+				}
+				FROM.FROM = {
+					TUR_restore_dynamic_modifiers_effect = yes
+				}
+			}		
+		}
+		effect = { #Check for Macedonian state modifiers
+			if = {
+				limit = {
+					FROM.FROM = { BUL_is_macedonian_state = yes }
+				}
+				#Widespread Sentiment
+				if = {
+					limit = {
+						FROM.FROM = { has_dynamic_modifier = { modifier = widespread_bulgarian_sentiment_01 } }
+						ROOT = { tag = BUL }
+					}
+					FROM.FROM = {
+						remove_dynamic_modifier = { modifier = widespread_bulgarian_sentiment_01 }
+						add_dynamic_modifier = { modifier = widespread_bulgarian_sentiment_02 }
+					}
+				}
+				else_if = {
+					limit = {
+						FROM.FROM = { has_dynamic_modifier = { modifier = widespread_bulgarian_sentiment_02 } }
+						ROOT = { NOT = { tag = BUL } }
+					}
+					FROM.FROM = {
+						remove_dynamic_modifier = { modifier = widespread_bulgarian_sentiment_02 }
+						add_dynamic_modifier = { modifier = widespread_bulgarian_sentiment_01 }
+					}
+				}
+				#IMRO Skirmishes
+				if = {
+					limit = {
+						FROM.FROM = {
+							has_dynamic_modifier = { modifier = skirmishes_against_imro }
+						}
+						ROOT = { tag = BUL }
+					}
+					FROM.FROM = {
+						remove_dynamic_modifier = { modifier = skirmishes_against_imro }
+					}
+				}
+			}
+		}
+	}
+
+	#FROM is faction leader on join faction requests. THIS DOES NOT FIRE ON ADD_TO_FACTION EFFECT! USE ON_OFFER_JOIN_FACTION!
+	on_join_faction = {
+		effect = {
+			if = {
+				limit = {
+					original_tag = GRE
+					OR = { 
+						GRE = { has_idea = GRE_metaxism }
+						GRE = { has_idea = GRE_metaxism_2 }
+						GRE = { has_idea = GRE_metaxism_3 }
+						GRE = { has_idea = GRE_metaxism_4 }
+						GRE = { has_idea = GRE_metaxism_5 }
+					}
+				}
+				GRE = { 
+					remove_ideas = GRE_metaxism
+					remove_ideas = GRE_metaxism_2 
+					remove_ideas = GRE_metaxism_3 
+					remove_ideas = GRE_metaxism_4 
+					remove_ideas = GRE_metaxism_5 
+				}
+			}
+		}
+		effect = { #If in faction with Bulgaria, remove bad opinion modifiers
+			if = { #A country joins Bulgaria's faction
+				limit = {
+					NOT = { original_tag = BUL }
+					FROM = {
+						OR = {
+							is_in_faction_with = BUL
+							original_tag = BUL
+						}
+					}
+				}
+				BUL_remove_balkan_opinion_modifiers = yes
+			}
+			else_if = { #Bulgaria joins a faction
+				limit = {
+					original_tag = BUL
+					FROM = {
+						any_allied_country = {
+							BUL_is_balkan_nation_no_bulgaria = yes
+						}
+					}
+				}
+				every_other_country = {
+					limit = {
+						is_in_faction_with = FROM
+						BUL_is_balkan_nation_no_bulgaria = yes
+					}
+					BUL_remove_balkan_opinion_modifiers = yes
+				}
+			}
+		}
+	}
+
+	#FROM is country getting invited.
+	on_offer_join_faction = {
+		effect = { #If in faction with Bulgaria, remove bad opinion modifiers
+			if = { #A country joins Bulgaria's faction
+				limit = {
+					is_in_faction_with = BUL
+					FROM = {
+						NOT = { original_tag = BUL }
+					}
+				}
+				FROM = { BUL_remove_balkan_opinion_modifiers = yes }
+			}
+			else_if = { #Bulgaria joins a faction
+				limit = {
+					FROM = {
+						original_tag = BUL
+					}
+					OR = {
+						BUL_is_balkan_nation_no_bulgaria = yes
+						any_allied_country = {
+							BUL_is_balkan_nation_no_bulgaria = yes
+						}
+					}
+				}
+				every_country = {
+					limit = {
+						OR = {
+							tag = PREV
+							is_in_faction_with = PREV
+						}
+						BUL_is_balkan_nation_no_bulgaria = yes
+					}
+					BUL_remove_balkan_opinion_modifiers = yes
+				}
+			}
+		}
+	}
+
+	on_startup = {
+		effect = {
+			#Iraqi oil concessions
+			if = {
+				limit = {
+					has_dlc = "Battle for the Bosporus"
+				}
+				IRQ = {
+					give_resource_rights = { receiver = ENG state = 291 }
+					give_resource_rights = { receiver = ENG state = 676 }
+					give_resource_rights = { receiver = ENG state = 1010 }
+				}
+			}
+		}
+		effect = {
+			#Greek faction set-up
+			if = {
+				limit = {
+					has_dlc = "Battle for the Bosporus"
+					has_start_date < 1936.1.2
+				}
+				GRE = { 
+					set_country_flag = GRE_factions_unlocked
+					set_variable = { var  = GRE_monarchist_loyalty value = 2 }
+					set_variable = { var  = GRE_republican_loyalty value = -1 }
+					set_variable = { var  = GRE_communist_loyalty value = -1 }
+					set_variable = { var  = GRE_fascist_loyalty value = -2 }
+					GRE_political_instability_update_effect = yes
+				}
+			}
+		}
+	}
+
+	#ROOT is winner #FROM gets annexed - This will also fire on_annex
+	on_civil_war_end = {
+		effect = {
+			if = {
+				limit = {
+					original_tag = GRE
+					date < 1937.01.01
+				}
+				set_country_flag = achievement_greek_civility
+			}
+			if = {
+				limit = {
+					any_country = { 
+						AND = { 
+							has_country_flag = TUR_iraqi_government_flag 
+							exists = yes
+						}
+					}
+				}
+				TUR = {  
+					create_wargoal = {
+						type = puppet_wargoal_focus
+						target = IRQ
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					any_country = { 
+						AND = { 
+							has_country_flag = TUR_iraqi_fascists_flag 
+							exists = yes
+						}
+					}
+				}
+				ENG = { 
+					remove_resource_rights = 676
+					remove_resource_rights = 291
+				}
+				TUR = { country_event = { id = bftb_turkey.69 hours = 6 } } 
+				GER = { country_event = { id = bftb_turkey.71 hours = 8 } } 
+				ITA = { country_event = { id = bftb_turkey.73 hours = 8 } } 
+				if = {
+					limit = {
+						IRQ = { NOT = { has_idea = nationalism } }
+					}
+					add_ideas = nationalism
+				}
+			}
+		}
+		effect = {
+			if = { 
+				limit = {
+					original_tag = BUL
+					has_dlc = "Battle for the Bosporus"
+				}
+				#Set Sofia as capital
+				if = {
+					limit = {
+						controls_state = 48
+						48 = { is_capital = no }
+					}
+					set_capital = { state = 48 }
+				}
+				if = { #Unlock faction interaction
+					limit = {					
+						NOT = { has_country_flag = BUL_factions_unlocked_flag }
+						NOT = { has_focus_tree = generic_focus }
+					}
+					set_country_flag = BUL_factions_unlocked_flag
+				}
+				if = { #ZVENO Bulgaria won the CW
+					limit = {
+						has_cosmetic_tag = BUL_zveno_bulgaria
+						has_focus_tree = generic_focus
+					}
+					load_focus_tree = { tree = bulgarian_focus keep_completed = no }
+					unlock_national_focus = BUL_power_to_the_tsar
+					unlock_national_focus = BUL_cooperate_with_the_zveno
+					unlock_national_focus = BUL_condemn_macedonian_organizations
+					unlock_national_focus = BUL_appoint_right_wing_ministers
+					unlock_national_focus = BUL_promote_bulgarian_nationalism
+					unlock_national_focus = BUL_bulgarian_irredentism
+					unlock_national_focus = BUL_depose_the_tsar
+					unlock_national_focus = BUL_military_dictatorship
+
+					#Initialize vars
+					BUL_set_buz_faction_values = yes
+
+					if = {
+						limit = {
+							has_government = fascism
+						}
+						unlock_national_focus = BUL_allow_far_right_organizations
+					}
+					set_country_flag = BUL_zveno_integrated_flag
+					clr_country_flag = BUL_zveno_coup_flag
+				}
+				else_if = { #Original BUL won the CW against ZVENO
+					limit = {
+						FROM = {
+							has_cosmetic_tag = BUL_zveno_bulgaria
+						}
+					}
+					if = {
+						limit = {
+							NOT = { has_completed_focus = BUL_dissolve_the_military_union }
+						}
+						unlock_national_focus = BUL_dissolve_the_military_union
+					}
+					set_country_flag = BUL_zveno_destroyed_flag
+					set_country_flag = BUL_factions_unlocked_flag
+					clr_country_flag = BUL_zveno_coup_flag
+				}
+				else_if = { #FATHERLAND FRONT won the CW
+					limit = {
+						original_tag = BUL
+						has_country_flag = BUL_fatherland_front_flag
+						has_focus_tree = generic_focus
+					}
+					#FOCUS TREE
+					load_focus_tree = { tree = bulgarian_focus keep_completed = no }
+					unlock_national_focus = BUL_oppose_the_royal_dictatorship
+					unlock_national_focus = BUL_appoint_communist_ministers
+					unlock_national_focus = BUL_unify_the_bourgeois_movement
+					unlock_national_focus = BUL_united_front_against_fascism
+					unlock_national_focus = BUL_the_fatherland_front
+					unlock_national_focus = BUL_overthrow_the_tsar
+					unlock_national_focus = BUL_the_peoples_republic_of_bulgaria
+					unlock_national_focus = BUL_condemn_macedonian_organizations
+					unlock_national_focus = BUL_acquire_modern_tools
+					unlock_national_focus = BUL_negotiate_bulgarian_rearmament
+
+					if = { #Lock faction interaction
+						limit = {					
+							has_country_flag = BUL_factions_unlocked_flag
+						}
+						clr_country_flag = BUL_factions_unlocked_flag
+					}
+					#SET Faction flags
+					if = {
+						limit = {
+							FROM = {
+								has_country_flag = BUL_zveno_joined_ff_flag
+							}
+						}
+						set_country_flag = BUL_zveno_integrated_flag
+						unlock_national_focus = BUL_cooperate_with_the_zveno
+					}
+					else = {
+						set_country_flag = BUL_zveno_destroyed_flag
+						unlock_national_focus = BUL_dissolve_the_military_union
+					}
+					if = {
+						limit = {
+							FROM = {
+								has_country_flag = BUL_bs_joined_ff_flag
+							}
+						}
+						set_country_flag = BUL_bs_integrated_flag
+					}
+					else = {
+						set_country_flag = BUL_bs_destroyed_flag
+					}
+					if = {
+						limit = {
+							FROM = {
+								has_country_flag = BUL_bzns_joined_ff_flag
+							}
+						}
+						set_country_flag = BUL_bzns_integrated_flag
+					}
+					else = {
+						set_country_flag = BUL_bzns_destroyed_flag
+					}
+					set_country_flag = BUL_nsm_destroyed_flag				
+
+					hidden_effect = { #NEWS EVENT SO THE WORLD KNOW WHO RULES IN BULGARIA
+						news_event = { id = bftb_news.8 hours = 4 random_hours = 4 }
+					}
+				}
+			}
+		}
+		effect = { #SCW
+			if = {
+				limit = {
+					FROM = {
+						original_tag = SPR
+					}
+					NOT = {
+						any_other_country = {
+							NOT = {
+								tag = ROOT
+								tag = FROM
+							}
+							original_tag = SPR
+							exists = yes
+						}
+					}
+				}
+				if = {
+					limit = {
+						BUL = { has_country_flag = BUL_sent_volunteers_to_SPD_flag }
+					}
+					BUL = { 
+						set_country_flag = BUL_back_from_the_scw_flag
+						country_event = { id = bftb_bulgaria_scw_volunteers.1 hours = 12 random_hours = 8 }
+						clr_country_flag = BUL_sent_volunteers_to_SPD_flag
+					}
+				}
+				else_if = {
+					limit = {
+						BUL = { has_country_flag = BUL_sent_volunteers_to_SPA_flag }
+					}
+					BUL = {						
+						country_event = { id = bftb_bulgaria_scw_volunteers.2 hours = 12 random_hours = 8 }
+						clr_country_flag = BUL_sent_volunteers_to_SPA_flag
+					}
+				}
+			}
+		}
+	}
+
+	# called when a country send volunteers to another
+	# ROOT is sender, FROM is receiver
+	on_send_volunteers = {
+		effect = {
+			if = { #Bulgaria has sent volunteers to Spanish Republicans/Nationalists (LaR)
+				limit = {
+					tag = BUL
+					FROM = { original_tag = SPR }
+					has_dlc = "La Resistance"
+					SPR_scw_in_progress = yes
+				}
+				if = {
+					limit = {
+						FROM = { tag = SPD }
+					}
+					set_country_flag = BUL_sent_volunteers_to_SPD_flag
+				}
+				else = {
+					set_country_flag = BUL_sent_volunteers_to_SPA_flag
+				}
+			}
+			else_if = {
+				limit = {
+					tag = BUL
+					FROM = { original_tag = SPR }
+					NOT = { has_dlc = "La Resistance" }
+					FROM = { has_civil_war = yes }
+				}
+				if = {
+					limit = {
+						FROM = {
+							OR = {
+								has_government = democratic
+								has_government = communism
+							}
+						}
+					}
+					set_country_flag = BUL_sent_volunteers_to_SPD_flag
+				}
+				else = {
+					set_country_flag = BUL_sent_volunteers_to_SPA_flag
+				}
+			}	
+		}
+	}
+
+	on_ruling_party_change = {
+		# Change 3D Models based on ideology
+		effect = {
+			if = {
+				limit = {
+					original_tag = BUL
+				}
+				if = { #BUL - TBE
+					limit = {
+						has_country_flag = BUL_tbe_flag
+					}
+					if = {
+						limit = {
+							has_government = communism
+						}
+						set_cosmetic_tag = TBE_third_bulgarian_empire_communism
+					}
+					else_if = {
+						limit = {
+							has_government = democratic
+						}
+						set_cosmetic_tag = TBE_third_bulgarian_empire_democratic
+					}
+					else_if = {
+						limit = {
+							has_government = fascism
+						}
+						set_cosmetic_tag = TBE_third_bulgarian_empire_fascism
+					}
+					else = {
+						limit = {
+							has_government = neutrality
+						}
+						set_cosmetic_tag = TBE_third_bulgarian_empire_neutrality
+					}
+				}
+				else_if = {  #BUL - UBF
+					limit = {
+						has_country_flag = BUL_ubf_flag
+					}
+					if = {
+						limit = {
+							has_government = communism
+						}
+						set_cosmetic_tag = UBF_united_balkan_federation_communism
+					}
+					else_if = {
+						limit = {
+							has_government = democratic
+						}
+						set_cosmetic_tag = UBF_united_balkan_federation_democratic
+					}
+					else_if = {
+						limit = {
+							has_government = fascism
+						}
+						set_cosmetic_tag = UBF_united_balkan_federation_fascism
+					}
+					else = {
+						limit = {
+							has_government = neutrality
+						}
+						set_cosmetic_tag = UBF_united_balkan_federation_neutrality
+					}
+				}
+				else_if = { #BUL - The fabulous original one
+					limit = {
+						NOT = { has_cosmetic_tag = BUL_zveno_bulgaria } # NOT Zveno Bulgaria
+					}
+					if = {
+						limit = {
+							has_government = communism
+							NOT = { has_cosmetic_tag = BUL_ff_bulgaria } # NOT Fatherland Front Bulgaria
+						}
+						set_cosmetic_tag = BUL_communism
+					}
+					else_if = { #Default democratic Bulgaria's name is "Republic of Bulgaria", so it is to be applied only if monarchy is actually abolished
+						limit = {
+							has_government = communism
+							has_cosmetic_tag = BUL_ff_bulgaria # Fatherland Front Bulgaria
+						}
+						#DO NOTHING
+					}
+					else_if = {
+						limit = {
+							has_government = democratic
+							has_completed_focus = BUL_abolish_the_monarchy
+						}
+						if = {
+							limit = {
+								has_cosmetic_tag = BUL_ff_bulgaria #Remove FF cosmetic
+							}
+							drop_cosmetic_tag = yes
+						}
+						set_cosmetic_tag = BUL_democratic
+						set_country_leader_ideology = socialism
+					}
+					else_if = { #Cosmetic tag with a non-republican name, so it is to be applied as long as monarchy has not been abolished
+						limit = {
+							has_government = democratic
+							NOT = { has_completed_focus = BUL_abolish_the_monarchy }
+						}
+						set_cosmetic_tag = BUL_constitutional_monarchy
+					}
+					else_if = {
+						limit = {
+							has_government = fascism
+						}
+						if = {
+							limit = {
+								has_cosmetic_tag = BUL_ff_bulgaria #Remove FF cosmetic
+							}
+							drop_cosmetic_tag = yes
+						}
+						set_cosmetic_tag = BUL_fascism
+					}
+					else = {
+						limit = {
+							has_government = neutrality
+						}
+						if = {
+							limit = {
+								has_cosmetic_tag = BUL_ff_bulgaria #Remove FF cosmetic
+							}
+							drop_cosmetic_tag = yes
+						}
+						set_cosmetic_tag = BUL_neutrality
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					original_tag = GRE
+				}
+				if = { #GRE - BYZ_UNIFIED
+					limit = {
+						has_country_flag = GRE_byz_unified_flag
+					}
+					if = {
+						limit = {
+							has_government = communism
+						}
+						set_cosmetic_tag = BYZ_UNIFIED_communism
+					}
+					else_if = {
+						limit = {
+							has_government = democratic
+						}
+						set_cosmetic_tag = BYZ_UNIFIED_democratic
+					}
+					else_if = {
+						limit = {
+							has_government = fascism
+						}
+						set_cosmetic_tag = BYZ_UNIFIED_fascism
+					}
+					else = {
+						limit = {
+							has_government = neutrality
+						}
+						set_cosmetic_tag = BYZ_UNIFIED_neutrality
+					}
+				}
+				else_if = { #GRE BYZANTINE REPUBLIC
+					limit = {
+						has_cosmetic_tag = GRE_byz_republic
+					}
+					#DO NOTHING, this cosmetic does not have dynamic models
+				}
+				else_if = { #GRE - GRE_GREATER_GREECE
+					limit = {
+						has_country_flag = GRE_GREATER_GREECE_flag
+					}
+					if = {
+						limit = {
+							has_government = communism
+						}
+						set_cosmetic_tag = GRE_GREATER_GREECE_communism
+					}
+					else_if = {
+						limit = {
+							has_government = democratic
+						}
+						set_cosmetic_tag = GRE_GREATER_GREECE_democratic
+					}
+					else_if = {
+						limit = {
+							has_government = fascism
+						}
+						set_cosmetic_tag = GRE_GREATER_GREECE_fascism
+					}
+					else = {
+						limit = {
+							has_government = neutrality
+						}
+						set_cosmetic_tag = GRE_GREATER_GREECE_neutrality
+					}
+				}
+				else_if = { #GRE - GRE_dem_monarchy
+					limit = {
+						has_country_flag = GRE_dem_monarchy_flag
+					}
+					if = {
+						limit = {
+							has_government = communism
+						}
+						set_cosmetic_tag = GRE_dem_monarchy_communism
+					}
+					else_if = {
+						limit = {
+							has_government = democratic
+						}
+						set_cosmetic_tag = GRE_dem_monarchy_democratic
+					}
+					else_if = {
+						limit = {
+							has_government = fascism
+						}
+						set_cosmetic_tag = GRE_dem_monarchy_fascism
+					}
+					else = {
+						limit = {
+							has_government = neutrality
+						}
+						set_cosmetic_tag = GRE_dem_monarchy_neutrality
+					}
+				}
+				else_if = { #GRE - Stalinist
+					limit = {
+						has_cosmetic_tag = GRE_stalinist
+					}
+					#DO NOTHING, this cosmetic does not have dynamic models
+				}
+				else_if = { #GRE - GRE_com_independent
+					limit = {
+						has_country_flag = GRE_com_independent_flag
+					}
+					if = {
+						limit = {
+							has_government = communism
+						}
+						set_cosmetic_tag = GRE_com_independent_communism
+					}
+					else_if = {
+						limit = {
+							has_government = democratic
+						}
+						set_cosmetic_tag = GRE_com_independent_democratic
+					}
+					else_if = {
+						limit = {
+							has_government = fascism
+						}
+						set_cosmetic_tag = GRE_com_independent_fascism
+					}
+					else = {
+						limit = {
+							has_government = neutrality
+						}
+						set_cosmetic_tag = GRE_com_independent_neutrality
+					}
+				}
+				else_if = { #GRE - MAE
+					limit = {
+						has_country_flag = GRE_mae_flag
+					}
+					if = {
+						limit = {
+							has_government = communism
+						}
+						set_cosmetic_tag = MAE_communism
+					}
+					else_if = {
+						limit = {
+							has_government = democratic
+						}
+						set_cosmetic_tag = MAE_democratic
+					}
+					else_if = {
+						limit = {
+							has_government = fascism
+						}
+						set_cosmetic_tag = MAE_fascism
+					}
+					else = {
+						limit = {
+							has_government = neutrality
+						}
+						set_cosmetic_tag = MAE_neutrality
+					}
+				}
+				else = { #GRE - The one and only
+					if = {
+						limit = {
+							has_government = communism
+						}
+						set_cosmetic_tag = GRE_communism
+					}
+					else_if = {
+						limit = {
+							has_government = democratic
+						}
+						set_cosmetic_tag = GRE_democratic
+					}
+					else_if = {
+						limit = {
+							has_government = fascism
+						}
+						set_cosmetic_tag = GRE_fascism
+					}
+					else = {
+						limit = {
+							has_government = neutrality
+						}
+						set_cosmetic_tag = GRE_neutrality
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					original_tag = TUR
+				}
+				if = { #TUR - OTT_UNIFIED
+					limit = {
+						has_country_flag = TUR_ott_unified_flag
+					}
+					if = {
+						limit = {
+							has_government = communism
+						}
+						set_cosmetic_tag = OTT_UNIFIED_communism
+					}
+					else_if = {
+						limit = {
+							has_government = democratic
+						}
+						set_cosmetic_tag = OTT_UNIFIED_democratic
+					}
+					else_if = {
+						limit = {
+							has_government = fascism
+						}
+						set_cosmetic_tag = OTT_UNIFIED_fascism
+					}
+					else_if = {
+						limit = {
+							has_government = neutrality
+						}
+						set_cosmetic_tag = OTT_UNIFIED_neutrality
+					}
+				}
+				else_if = { #TUR - OTT_SULTANATE
+					limit = {
+						has_country_flag = TUR_ott_sultanate_flag
+					}
+					if = {
+						limit = {
+							has_government = communism
+						}
+						set_cosmetic_tag = OTT_SULTANATE_communism
+					}
+					else_if = {
+						limit = {
+							has_government = democratic
+						}
+						set_cosmetic_tag = OTT_SULTANATE_democratic
+					}
+					else_if = {
+						limit = {
+							has_government = fascism
+						}
+						set_cosmetic_tag = OTT_SULTANATE_fascism
+					}
+					else_if = {
+						limit = {
+							has_government = neutrality
+						}
+						set_cosmetic_tag = OTT_SULTANATE_neutrality
+					}
+				}
+				else_if = { #TUR - TUR_PROVISIONARY
+					limit = {
+						has_country_flag = TUR_PROVISIONARY_flag
+					}
+					if = {
+						limit = {
+							has_government = communism
+						}
+						set_cosmetic_tag = TUR_PROVISIONARY_communism
+					}
+					else_if = {
+						limit = {
+							has_government = democratic
+						}
+						set_cosmetic_tag = TUR_PROVISIONARY_democratic
+					}
+					else_if = {
+						limit = {
+							has_government = fascism
+						}
+						set_cosmetic_tag = TUR_PROVISIONARY_fascism
+					}
+					else_if = {
+						limit = {
+							has_government = neutrality
+						}
+						set_cosmetic_tag = TUR_PROVISIONARY_neutrality
+					}
+				}
+				else_if = { #TUR - TUR_GREATER_TURKEY
+					limit = {
+						has_country_flag = TUR_greater_turkey_flag
+					}
+					if = {
+						limit = {
+							has_government = communism
+						}
+						set_cosmetic_tag = TUR_GREATER_TURKEY_communism
+					}
+					else_if = {
+						limit = {
+							has_government = democratic
+						}
+						set_cosmetic_tag = TUR_GREATER_TURKEY_democratic
+					}
+					else_if = {
+						limit = {
+							has_government = fascism
+						}
+						set_cosmetic_tag = TUR_GREATER_TURKEY_fascism
+					}
+					else_if = {
+						limit = {
+							has_government = neutrality
+						}
+						set_cosmetic_tag = TUR_GREATER_TURKEY_neutrality
+					}
+				}
+				else_if = { #TRN
+					limit = {
+						has_country_flag = TUR_trn_flag
+					}
+					if = {
+						limit = {
+							has_government = communism
+						}
+						set_cosmetic_tag = TRN_communism
+					}
+					else_if = {
+						limit = {
+							has_government = democratic
+						}
+						set_cosmetic_tag = TRN_democratic
+					}
+					else_if = {
+						limit = {
+							has_government = fascism
+						}
+						set_cosmetic_tag = TRN_fascism
+					}
+					else_if = {
+						limit = {
+							has_government = neutrality
+						}
+						set_cosmetic_tag = TRN_neutrality
+					}
+				}
+				else = { #TUR - The real TUR
+					if = {
+						limit = {
+							has_government = communism
+						}
+						set_cosmetic_tag = TUR_communism
+					}
+					else_if = {
+						limit = {
+							has_government = democratic
+						}
+						set_cosmetic_tag = TUR_democratic
+					}
+					else_if = {
+						limit = {
+							has_government = fascism
+						}
+						set_cosmetic_tag = TUR_fascism
+					}
+					else_if = {
+						limit = {
+							has_government = neutrality
+						}
+						set_cosmetic_tag = TUR_neutrality
+					}
+				}
+			}
+		}
+		effect = {
+			if = {
+				limit = {
+					original_tag = BUL
+				}
+				if = {
+					limit = {
+						has_government = communism
+						has_country_flag = BUL_player_formed_fatherland_front_flag
+					}
+					add_ideas = BUL_fatherland_front_positive
+					clr_country_flag = BUL_player_formed_fatherland_front_flag
+				}
+				else_if = {
+					limit = {
+						has_government = fascism
+						has_idea = BUL_bogdan_filov
+					}
+					remove_ideas = BUL_bogdan_filov
+					add_ideas = BUL_bogdan_filov_fascism
+				}
+				else_if = {
+					limit = {
+						has_government = neutrality
+						has_idea = BUL_bogdan_filov_fascism
+					}
+					remove_ideas = BUL_bogdan_filov_fascism
+					add_ideas = BUL_bogdan_filov
+				}
+			}
+		}
+		effect = {
+			if = {
+				limit = {
+					original_tag = BUL
+					has_country_leader = {
+						character = BUL_ferdinand_i 
+						ruling_only = yes
+					}
+					num_subjects > 0
+				}
+				every_other_country = {
+					limit = {
+						is_subject_of = BUL
+						NOT = { has_idea = BUL_ferdinands_puppet }
+					}
+					add_ideas = BUL_ferdinands_puppet
+				}
+			}
+			else_if = {
+				limit = {
+					original_tag = BUL
+					has_country_flag = BUL_the_return_of_ferdinand_flag
+					NOT = {
+						has_country_leader = {
+							character = BUL_ferdinand_i 
+							ruling_only = yes
+						}
+					}
+					num_subjects > 0
+				}
+				every_other_country = {
+					limit = {
+						is_subject_of = BUL
+						has_idea = BUL_ferdinands_puppet
+					}
+					remove_ideas = BUL_ferdinands_puppet
+				}
+			}
+		}
+	}
+
+	on_weekly_BUL = {
+		effect = {
+			# FATHERLAND FRONT
+			if = {
+				limit = {
+					has_dlc = "Battle for the Bosporus"
+					NOT = { has_country_flag = BUL_fatherland_front_formed_flag }
+					NOT = { has_completed_focus = BUL_the_fatherland_front }
+					date > 1941.6.1 #Previously date > 1940.1.1 but it felt too punishing
+				}
+				BUL_communists_try_to_form_ff_effect = yes
+			}
+			else_if = {
+				limit = {
+					NOT = { has_country_flag = BUL_ff_civil_war_flag }
+					NOT = { has_country_flag = BUL_ff_destroyed_flag }
+					has_country_flag = { flag = BUL_fatherland_front_formed_flag days > 60 } #Give the player some time after FF formation
+					OR = {
+						NOT = { has_country_flag = BUL_ff_approaching_faction_flag }
+						has_country_flag = { flag = BUL_ff_approaching_faction_flag days > 30 }
+					}
+				}
+				log = "checking if FF approaches someone"
+				# CHECK IF FF APPROACHES ANY BULARIAN INTERNAL FACTION
+				BUL_ff_approaches_a_faction_effect = yes #Random chance
+
+				if = { # Check if FF approaches BROAD SOCIALISTS
+					limit = { 
+						NOT = { has_country_flag = BUL_bs_joined_ff_flag }
+						NOT = { has_country_flag = BUL_bs_destroyed_flag }
+						NOT = { has_country_flag = BUL_bs_integrated_flag }
+					}
+					set_temp_variable = { BUL_bs_loyalty_factor = 100 }
+					subtract_from_temp_variable = { BUL_bs_loyalty_factor = BUL_bs_loyalty }
+					if = {
+						limit = {
+							check_variable = { BUL_bs_loyalty_factor = BUL_random_ff_approaching_faction_chance compare = greater_than_or_equals }
+						}
+						if = {
+							limit = { has_country_flag = BUL_ff_approaching_faction_flag }
+							clr_country_flag = BUL_ff_approaching_faction_flag
+						}
+						set_country_flag = BUL_bs_joined_ff_flag
+						set_country_flag = BUL_ff_approaching_faction_flag
+						activate_mission = BUL_ff_approaching_bs_mission
+
+						log = "FF approaches BS: [?BUL.BUL_bs_loyalty_factor] is greater than [?BUL.BUL_random_ff_approaching_faction_chance]"
+					}
+					else = {
+						log = "FF DOES NOT approach BS: [?BUL.BUL_bs_loyalty_factor] is lower than [?BUL.BUL_random_ff_approaching_faction_chance]"
+					}
+				}
+				else_if = { # Check if FF approaches AGRARIAN NATIONAL UNION
+					limit = {
+						NOT = { has_country_flag = BUL_bzns_joined_ff_flag }
+						NOT = { has_country_flag = BUL_bzns_destroyed_flag }
+						NOT = { has_country_flag = BUL_bzns_integrated_flag }
+					}
+					set_temp_variable = { BUL_bzns_loyalty_factor = 100 }
+					subtract_from_temp_variable = { BUL_bzns_loyalty_factor = BUL_bs_loyalty }
+					if = {
+						limit = {
+							check_variable = { BUL_bzns_loyalty_factor = BUL_random_ff_approaching_faction_chance compare = greater_than_or_equals }
+						}
+						if = {
+							limit = { has_country_flag = BUL_ff_approaching_faction_flag }
+							clr_country_flag = BUL_ff_approaching_faction_flag
+						}
+						set_country_flag = BUL_bzns_joined_ff_flag
+						set_country_flag = BUL_ff_approaching_faction_flag
+						activate_mission = BUL_ff_approaching_bzns_mission
+
+						log = "FF approaches BZN: [?BUL.BUL_bzns_loyalty_factor] is greater than [?BUL.BUL_random_ff_approaching_faction_chance]"
+					}
+					else = {
+						log = "FF DOES NOT approach BZNS: [?BUL.BUL_bzns_loyalty_factor] is lower than [?BUL.BUL_random_ff_approaching_faction_chance]"
+					}
+				}
+				else_if = { # Check if FF approaches ZVENO
+					limit = { 
+						NOT = { has_country_flag = BUL_zveno_joined_ff_flag }
+						NOT = { has_country_flag = BUL_zveno_coup_flag }
+						NOT = { has_country_flag = BUL_zveno_destroyed_flag }
+						NOT = { has_country_flag = BUL_zveno_integrated_flag }
+					}
+					set_temp_variable = { BUL_zveno_loyalty_factor = 100 }
+					subtract_from_temp_variable = { BUL_zveno_loyalty_factor = BUL_zveno_loyalty }
+					if = {
+						limit = {
+							check_variable = { BUL_zveno_loyalty_factor = BUL_random_ff_approaching_faction_chance compare = greater_than_or_equals }
+						}
+						if = {
+							limit = { has_country_flag = BUL_ff_approaching_faction_flag }
+							clr_country_flag = BUL_ff_approaching_faction_flag
+						}
+						set_country_flag = BUL_zveno_joined_ff_flag
+						set_country_flag = BUL_ff_approaching_faction_flag
+						activate_mission = BUL_ff_approaching_zveno_mission
+
+						log = "FF approaches ZVENO: [?BUL.BUL_zveno_loyalty_factor] is greater than [?BUL.BUL_random_ff_approaching_faction_chance]"
+					}
+					else = {
+						log = "FF DOES NOT approach ZVENO: [?BUL.BUL_zveno_loyalty_factor] is lower than [?BUL.BUL_random_ff_approaching_faction_chance]"
+					}
+				}
+				if = {
+					limit = {
+						has_country_flag = BUL_ff_coup_planned_flag
+						date > 1943.1.1
+					}
+					BUL_ff_tries_to_stage_a_coup_effect = yes #Check if the FF starts the CW
+				}					
+			}
+
+			# BULGARIAN CLAIMS IN THE BALKANS
+			if = {
+				limit = {
+					has_global_flag = BUL_germany_recognizes_bulgarian_claims_flag
+					is_in_faction_with = GER
+					any_state = {
+						has_state_flag = BUL_bulgarian_claim_warranted_flag
+						OR = {
+							is_controlled_by = GER
+							controller = {
+								is_in_faction_with = GER
+								NOT = { tag = BUL }
+								NOT = { owns_state = PREV } #Not owner (it should be actually occupating the state -> Also prevents the issue in YUG with IMRO removing the core)
+								#NOT = { PREV.PREV = { is_core_of = PREV } }
+							}
+						}
+					}
+				}
+				country_event = bftb_bulgarian_claims.4
+			}
+		}
+		#Check for any subject not having the appropriate NS while Ferdinand I is ruling (ie. released nations)
+		effect = {
+			if = {
+				limit = {
+					has_country_leader = {
+						character = BUL_ferdinand_i 
+						ruling_only = yes
+					}
+					any_country = {
+						is_subject_of = ROOT
+						NOT = { has_idea = BUL_ferdinands_puppet }
+					}
+				}
+				every_country = {
+					limit = {
+						is_subject_of = ROOT
+						NOT = { has_idea = BUL_ferdinands_puppet }
+					}
+					add_ideas = BUL_ferdinands_puppet
+				}		
+			}
+		}
+
+		#Retire Generals that do not agree with pro-German policies
+		effect = {
+			if = {
+				limit = {
+					is_in_faction_with = GER
+					GER = { has_government = fascism }
+				}
+				random_unit_leader = {
+					limit = {
+						has_id = 1203 #Hadzipetkov
+					}
+					retire = yes
+				}
+				random_unit_leader = {
+					limit = {
+						has_id = 1204 #Boydev
+					}
+					retire = yes
+				}
+			}
+		}
+	}
+	
+	#ROOT = attacking side
+	#FROM = defending side
+	#fired when two countries end up at war with each other (on_war is fired when a country goes to war against anyone and is not fired again when it enters war against another country unless it went to peace first)
+	on_war_relation_added = {
+		effect = { #Bulgaria vs SOV -> Cooldown before high chance of FF forming up
+			if = {
+				limit = {
+					OR = {
+						AND = {
+							ROOT = { original_tag = BUL }
+							FROM = { original_tag = SOV }
+						}
+						AND = {
+							ROOT = { original_tag = SOV }
+							FROM = { original_tag = BUL }
+						}
+					}
+					
+					BUL = { NOT = { has_country_flag = BUL_at_war_with_the_soviets_flag } }
+				}
+				BUL = { set_country_flag = BUL_at_war_with_the_soviets_flag }
+			}
+		}
+		effect = {
+			if = {
+				limit = {
+					OR = {
+						AND = {
+							original_tag = ITA
+							FROM = {
+								original_tag = GRE
+							}
+						}
+						AND = {
+							original_tag = GRE
+							FROM = {
+								original_tag = ITA
+							}
+						}
+					}
+					OR = {
+						has_country_flag = GRE_italy_attending_convention
+						FROM = { has_country_flag = GRE_italy_attending_convention }
+					}
+				}
+				GRE = {
+					clr_country_flag = GRE_italy_attending_convention
+				}
+			}
+		}
+		effect = {
+			if = {
+				limit = { 
+					FROM = {
+						original_tag = BUL 
+					}
+					ROOT = {
+						original_tag = BUL
+					}
+					YUG = { has_completed_focus = YUG_recognize_the_soviet_union }
+				}
+				random_country = {
+					limit = {
+						original_tag = BUL
+						has_government = communism
+					}
+					set_cosmetic_tag = YUG_puppet_1
+				}
+			}
+			if = {
+				limit = { 
+					FROM = {
+						original_tag = ALB 
+					}
+					ROOT = {
+						original_tag = ALB
+					}
+					YUG = { has_completed_focus = YUG_recognize_the_soviet_union }
+				}
+				random_country = {
+					limit = {
+						original_tag = ALB
+						has_government = communism
+					}
+					set_cosmetic_tag = YUG_puppet_2
+				}
+			}
+			if = {
+				limit = { 
+					FROM = {
+						original_tag = GRE 
+					}
+					ROOT = {
+						original_tag = GRE
+					}
+					YUG = { has_completed_focus = YUG_recognize_the_soviet_union }
+				}
+				random_country = {
+					limit = {
+						original_tag = GRE
+						has_government = communism
+					}
+					set_cosmetic_tag = YUG_puppet_3
+				}
+			}
+			if = {
+				limit = { 
+					FROM = {
+						original_tag = ROM 
+					}
+					ROOT = {
+						original_tag = ROM
+					}
+					YUG = { has_completed_focus = YUG_recognize_the_soviet_union }
+				}
+				random_country = {
+					limit = {
+						original_tag = ROM
+						has_government = communism
+					}
+					set_cosmetic_tag = YUG_puppet_4
+				}
+			}
+			if = {
+				limit = { 
+					FROM = {
+						original_tag = HUN 
+					}
+					ROOT = {
+						original_tag = HUN
+					}
+					YUG = { has_completed_focus = YUG_recognize_the_soviet_union }
+				}
+				random_country = {
+					limit = {
+						original_tag = HUN
+						has_government = communism
+					}
+					set_cosmetic_tag = YUG_puppet_5
+				}
+			}
+			if = {
+				limit = { 
+					FROM = {
+						original_tag = TUR 
+					}
+					ROOT = {
+						original_tag = TUR
+					}
+					YUG = { has_completed_focus = YUG_recognize_the_soviet_union }
+				}
+				random_country = {
+					limit = {
+						original_tag = TUR
+						has_government = communism
+					}
+					set_cosmetic_tag = YUG_puppet_6
+				}
+			}
+		}
+	}
+
+	#used when puppeting in a peace conference
+	#ROOT = nation being puppeted, FROM = overlord
+	on_puppet = {
+		effect = { #Add Ferdinand's puppet NS
+			if = {
+				limit = {
+					FROM = {
+						original_tag = BUL
+						has_country_leader = {
+							character = BUL_ferdinand_i 
+							ruling_only = yes
+						}
+					}
+					NOT = { has_idea = BUL_ferdinands_puppet }
+				}
+				add_ideas = BUL_ferdinands_puppet
+			}
+		}
+		effect = { #Remove bad opinion modifiers when puppetting
+			if = { #If puppeted by Bulgaria, remove bad opinion modifiers
+				limit = {
+					BUL_is_balkan_nation_no_bulgaria = yes
+					FROM = { original_tag = BUL }
+				}
+				BUL_remove_balkan_opinion_modifiers = yes
+			}
+			else_if = { #Bulgaria puppeted by a Balkan nation
+				limit = {
+					original_tag = BUL
+					FROM = { BUL_is_balkan_nation_no_bulgaria = yes }
+				}
+				FROM = { BUL_remove_balkan_opinion_modifiers = yes }
+			}
+		}
+	}
+
+	on_leave_faction = {
+		effect = {
+			if = {
+				limit = { 
+					FROM = {
+						original_tag = BUL
+						has_completed_focus = BUL_the_fate_of_the_balkans
+					}
+				}
+				FROM = {
+					create_wargoal = {
+						type = puppet_wargoal_focus
+						target = ROOT
+					}
+				}
+			}
+		}
+	}
+
+	on_monthly_BUL = {
+		effect = { #ZVENO DISSIDENT EVENT
+			if = {
+				limit = {
+					always = no #SPTChange: Remove Zveno BS (Only BS Zveno has is coup)
+					date > 1937.6.1	#Give the player some time
+					NOT = {	has_country_flag = BUL_zveno_destroyed_flag } #Zveno is not destroyed
+					NOT = {	has_country_flag = BUL_zveno_legalized_flag } #Zveno is not legalized
+				}
+				BUL = { country_event = bftb_bulgaria_factions.01 }
+			}
+		}
+		effect = { #BROAD SOCIALISTS DISSIDENT EVENT
+			if = {
+				limit = {
+					date > 1936.6.1	#Give the player some time
+					NOT = {	has_country_flag = BUL_bs_destroyed_flag } #BS is not destroyed
+					NOT = {	has_country_flag = BUL_bs_legalized_flag } #BS is not legalized
+				}
+				BUL = { country_event = bftb_bulgaria_factions.02 }
+			}
+		}
+		effect = { #AGRARIAN NATIONAL UNION DISSIDENT EVENT
+			if = {
+				limit = {
+					date > 1938.1.1	#Give the player some time
+					NOT = {	has_country_flag = BUL_bzns_destroyed_flag } #BZNS is not destroyed
+					NOT = {	has_country_flag = BUL_bzns_legalized_flag } #BZNS is not legalized
+				}
+				BUL = { country_event = bftb_bulgaria_factions.03 }
+			}
+		}
+		effect = { #NATIONAL SOCIAL MOVEMENT DISSIDENT EVENT
+			if = {
+				limit = {
+					date > 1937.6.1	#Give the player some time
+					NOT = {	has_country_flag = BUL_nsm_destroyed_flag } #NSM is not destroyed
+					NOT = {	has_country_flag = BUL_nsm_legalized_flag } #NSM is not legalized
+				}
+				BUL = { country_event = bftb_bulgaria_factions.04 }
+			}
+		}
+		effect = { #ZVENO COUP
+			if = {
+				limit = {
+					date > 1938.1.1	#Give the player some time
+					has_country_flag = BUL_zveno_dissident_event_flag #Zveno has triggered a dissident event
+					NOT = { has_country_flag = BUL_zveno_coup_flag } #Zveno CW has not started
+					NOT = {	has_country_flag = BUL_zveno_destroyed_flag } #Zveno is not destroyed
+					NOT = {	has_country_flag = BUL_zveno_legalized_flag } #Zveno is not legalized
+				}
+				BUL = { country_event = bftb_bulgaria_factions.05 }
+			}
+		}
+		effect = { #Tsar Boris Dies
+			if = { #Force Boris's death in historical
+				limit = {
+					is_historical_focus_on = yes
+					NOT = { has_completed_focus	= BUL_strengthen_the_royal_dictatorship }
+					BUL_has_abolished_monarchy = no
+					date > 1943.7.30 #Historical date of death is 1943.8.28
+					NOT = { has_country_flag = BUL_tsar_boris_is_dead_flag }
+					NOT = { has_country_flag = BUL_tsar_boris_assassinated_flag }
+				}
+				BUL = { country_event = { id = bftb_bulgaria_tsar_boris.2 days = 28 } }
+			}
+			else_if = { #Attempt to make Boris die if not historical
+				limit = {
+					is_historical_focus_on = no
+					NOT = { has_completed_focus	= BUL_strengthen_the_royal_dictatorship }
+					BUL_has_abolished_monarchy = no
+					date > 1943.1.1 #Historical date of death is 1943.8.28
+					NOT = { has_country_flag = BUL_tsar_boris_is_dead_flag }
+					NOT = { has_country_flag = BUL_tsar_boris_assassinated_flag }
+				}
+				BUL_tsar_boris_may_die_effect = yes
+			}
+		}
+
+		effect = { #Support the Spanish Coup - Check for a general assigned to volunteers in the SCW fighting for SPA (it cannot be any other side)
+			if = {
+				limit = {
+					has_country_flag = BUL_sent_volunteers_to_SPA_flag
+				}
+				if = {
+					limit = {
+						any_unit_leader = {
+							is_field_marshal = no
+							OR = {
+								is_leading_volunteer_group_with_original_country = SPR
+								is_leading_volunteer_group = SPR
+							}
+							NOT = { has_unit_leader_flag = BUL_scw_promotion_flag }
+						}
+					}
+					random_unit_leader = {
+						limit = {
+							is_field_marshal = no
+							OR = {
+								is_leading_volunteer_group_with_original_country = SPR
+								is_leading_volunteer_group = SPR
+							}
+						}
+						set_unit_leader_flag = BUL_scw_promotion_flag 
+					}
+				}
+			}
+		}
+	}
+
+	#ROOT is winner, FROM gets annexed.
+	on_annex = {
+		effect = {
+			if = {
+				limit = {
+					FROM = { tag = KUR}
+					ROOT = { tag = TUR }
+				}
+				TUR = {
+					350 = {
+						if = {
+							limit = {
+								is_owned_and_controlled_by = TUR
+							}
+							add_dynamic_modifier = { modifier = kurdish_agitation }
+						}
+					}
+
+					353 = {
+						if = {
+							limit = {
+								is_owned_and_controlled_by = TUR
+							}
+							add_dynamic_modifier = { modifier = kurdish_agitation }
+						}
+					}
+
+					352 = {
+
+						if = {
+							limit = {
+								is_owned_and_controlled_by = TUR
+							}
+							add_dynamic_modifier = { modifier = kurdish_separatism }
+						}
+					}
+
+					800 = {
+
+						if = {
+							limit = {
+								is_owned_and_controlled_by = TUR
+							}
+							add_dynamic_modifier = { modifier = kurdish_separatism }
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/common/scripted_effects/BUL_scripted_effects.txt
+++ b/common/scripted_effects/BUL_scripted_effects.txt
@@ -1,0 +1,2158 @@
+#Faction System
+#ZVENO
+BUL_zveno_low_loyalty_increase_effect = {
+	custom_effect_tooltip = BUL_zveno_tt
+	custom_effect_tooltip = BUL_low_loyalty_increase_tt
+	add_to_variable = { BUL_zveno_loyalty = BUL_faction_low_increase }
+	clamp_variable = {
+		var = BUL_zveno_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_zveno_low_popularity_increase_effect = {
+	custom_effect_tooltip = BUL_zveno_tt
+	custom_effect_tooltip = BUL_low_popularity_increase_tt
+	add_to_variable = { BUL_zveno_popularity = BUL_faction_low_increase }
+	clamp_variable = {
+		var = BUL_zveno_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_zveno_medium_loyalty_increase_effect = {
+	custom_effect_tooltip = BUL_zveno_tt
+	custom_effect_tooltip = BUL_medium_loyalty_increase_tt
+	add_to_variable = { BUL_zveno_loyalty = BUL_faction_medium_increase }
+	clamp_variable = {
+		var = BUL_zveno_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_zveno_medium_popularity_increase_effect = {
+	custom_effect_tooltip = BUL_zveno_tt
+	custom_effect_tooltip = BUL_medium_popularity_increase_tt
+	add_to_variable = { BUL_zveno_popularity = BUL_faction_medium_increase }
+	clamp_variable = {
+		var = BUL_zveno_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_zveno_high_loyalty_increase_effect = {
+	custom_effect_tooltip = BUL_zveno_tt
+	custom_effect_tooltip = BUL_high_loyalty_increase_tt
+	add_to_variable = { BUL_zveno_loyalty = BUL_faction_high_increase }
+	clamp_variable = {
+		var = BUL_zveno_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_zveno_high_popularity_increase_effect = {
+	custom_effect_tooltip = BUL_zveno_tt
+	custom_effect_tooltip = BUL_high_popularity_increase_tt
+	add_to_variable = { BUL_zveno_popularity = BUL_faction_high_increase }
+	clamp_variable = {
+		var = BUL_zveno_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_zveno_low_loyalty_decrease_effect = {
+	custom_effect_tooltip = BUL_zveno_tt
+	custom_effect_tooltip = BUL_low_loyalty_decrease_tt
+	add_to_variable = { BUL_zveno_loyalty = BUL_faction_low_decrease }
+	clamp_variable = {
+		var = BUL_zveno_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_zveno_low_popularity_decrease_effect = {
+	custom_effect_tooltip = BUL_zveno_tt
+	custom_effect_tooltip = BUL_low_popularity_decrease_tt
+	add_to_variable = { BUL_zveno_popularity = BUL_faction_low_decrease }
+	clamp_variable = {
+		var = BUL_zveno_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_zveno_medium_loyalty_decrease_effect = {
+	custom_effect_tooltip = BUL_zveno_tt
+	custom_effect_tooltip = BUL_medium_loyalty_decrease_tt
+	add_to_variable = { BUL_zveno_loyalty = BUL_faction_medium_decrease }
+	clamp_variable = {
+		var = BUL_zveno_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_zveno_medium_popularity_decrease_effect = {
+	custom_effect_tooltip = BUL_zveno_tt
+	custom_effect_tooltip = BUL_medium_popularity_decrease_tt
+	add_to_variable = { BUL_zveno_popularity = BUL_faction_medium_decrease }
+	clamp_variable = {
+		var = BUL_zveno_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_zveno_high_loyalty_decrease_effect = {
+	custom_effect_tooltip = BUL_zveno_tt
+	custom_effect_tooltip = BUL_high_loyalty_decrease_tt
+	add_to_variable = { BUL_zveno_loyalty = BUL_faction_high_decrease }
+	clamp_variable = {
+		var = BUL_zveno_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_zveno_high_popularity_decrease_effect = {
+	custom_effect_tooltip = BUL_zveno_tt
+	custom_effect_tooltip = BUL_high_popularity_decrease_tt
+	add_to_variable = { BUL_zveno_popularity = BUL_faction_high_decrease }
+	clamp_variable = {
+		var = BUL_zveno_popularity
+		min = 0
+		max = 100
+	}
+}
+
+#BROAD SOCIALISTS
+BUL_bs_low_loyalty_increase_effect = {
+	custom_effect_tooltip = BUL_bs_tt
+	custom_effect_tooltip = BUL_low_loyalty_increase_tt
+	add_to_variable = { BUL_bs_loyalty = BUL_faction_low_increase }
+	clamp_variable = {
+		var = BUL_bs_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_bs_low_popularity_increase_effect = {
+	custom_effect_tooltip = BUL_bs_tt
+	custom_effect_tooltip = BUL_low_popularity_increase_tt
+	add_to_variable = { BUL_bs_popularity = BUL_faction_low_increase }
+	clamp_variable = {
+		var = BUL_bs_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_bs_medium_loyalty_increase_effect = {
+	custom_effect_tooltip = BUL_bs_tt
+	custom_effect_tooltip = BUL_medium_loyalty_increase_tt
+	add_to_variable = { BUL_bs_loyalty = BUL_faction_medium_increase }
+	clamp_variable = {
+		var = BUL_bs_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_bs_medium_popularity_increase_effect = {
+	custom_effect_tooltip = BUL_bs_tt
+	custom_effect_tooltip = BUL_medium_popularity_increase_tt
+	add_to_variable = { BUL_bs_popularity = BUL_faction_medium_increase }
+	clamp_variable = {
+		var = BUL_bs_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_bs_high_loyalty_increase_effect = {
+	custom_effect_tooltip = BUL_bs_tt
+	custom_effect_tooltip = BUL_high_loyalty_increase_tt
+	add_to_variable = { BUL_bs_loyalty = BUL_faction_high_increase }
+	clamp_variable = {
+		var = BUL_bs_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_bs_high_popularity_increase_effect = {
+	custom_effect_tooltip = BUL_bs_tt
+	custom_effect_tooltip = BUL_high_popularity_increase_tt
+	add_to_variable = { BUL_bs_popularity = BUL_faction_high_increase }
+	clamp_variable = {
+		var = BUL_bs_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_bs_low_loyalty_decrease_effect = {
+	custom_effect_tooltip = BUL_bs_tt
+	custom_effect_tooltip = BUL_low_loyalty_decrease_tt
+	add_to_variable = { BUL_bs_loyalty = BUL_faction_low_decrease }
+	clamp_variable = {
+		var = BUL_bs_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_bs_low_popularity_decrease_effect = {
+	custom_effect_tooltip = BUL_bs_tt
+	custom_effect_tooltip = BUL_low_popularity_decrease_tt
+	add_to_variable = { BUL_bs_popularity = BUL_faction_low_decrease }
+	clamp_variable = {
+		var = BUL_bs_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_bs_medium_loyalty_decrease_effect = {
+	custom_effect_tooltip = BUL_bs_tt
+	custom_effect_tooltip = BUL_medium_loyalty_decrease_tt
+	add_to_variable = { BUL_bs_loyalty = BUL_faction_medium_decrease }
+	clamp_variable = {
+		var = BUL_bs_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_bs_medium_popularity_decrease_effect = {
+	custom_effect_tooltip = BUL_bs_tt
+	custom_effect_tooltip = BUL_medium_popularity_decrease_tt
+	add_to_variable = { BUL_bs_popularity = BUL_faction_medium_decrease }
+	clamp_variable = {
+		var = BUL_bs_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_bs_high_loyalty_decrease_effect = {
+	custom_effect_tooltip = BUL_bs_tt
+	custom_effect_tooltip = BUL_high_loyalty_decrease_tt
+	add_to_variable = { BUL_bs_loyalty = BUL_faction_high_decrease }
+	clamp_variable = {
+		var = BUL_bs_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_bs_high_popularity_decrease_effect = {
+	custom_effect_tooltip = BUL_bs_tt
+	custom_effect_tooltip = BUL_high_popularity_decrease_tt
+	add_to_variable = { BUL_bs_popularity = BUL_faction_high_decrease }
+	clamp_variable = {
+		var = BUL_bs_popularity
+		min = 0
+		max = 100
+	}
+}
+
+#AGRARIAN UNION
+BUL_bzns_low_loyalty_increase_effect = {
+	custom_effect_tooltip = BUL_bzns_tt
+	custom_effect_tooltip = BUL_low_loyalty_increase_tt
+	add_to_variable = { BUL_bzns_loyalty = BUL_faction_low_increase }
+	clamp_variable = {
+		var = BUL_bzns_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_bzns_low_popularity_increase_effect = {
+	custom_effect_tooltip = BUL_bzns_tt
+	custom_effect_tooltip = BUL_low_popularity_increase_tt
+	add_to_variable = { BUL_bzns_popularity = BUL_faction_low_increase }
+	clamp_variable = {
+		var = BUL_bzns_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_bzns_medium_loyalty_increase_effect = {
+	custom_effect_tooltip = BUL_bzns_tt
+	custom_effect_tooltip = BUL_medium_loyalty_increase_tt
+	add_to_variable = { BUL_bzns_loyalty = BUL_faction_medium_increase }
+	clamp_variable = {
+		var = BUL_bzns_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_bzns_medium_popularity_increase_effect = {
+	custom_effect_tooltip = BUL_bzns_tt
+	custom_effect_tooltip = BUL_medium_popularity_increase_tt
+	add_to_variable = { BUL_bzns_popularity = BUL_faction_medium_increase }
+	clamp_variable = {
+		var = BUL_bzns_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_bzns_high_loyalty_increase_effect = {
+	custom_effect_tooltip = BUL_bzns_tt
+	custom_effect_tooltip = BUL_high_loyalty_increase_tt
+	add_to_variable = { BUL_bzns_loyalty = BUL_faction_high_increase }
+	clamp_variable = {
+		var = BUL_bzns_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_bzns_high_popularity_increase_effect = {
+	custom_effect_tooltip = BUL_bzns_tt
+	custom_effect_tooltip = BUL_high_popularity_increase_tt
+	add_to_variable = { BUL_bzns_popularity = BUL_faction_high_increase }
+	clamp_variable = {
+		var = BUL_bzns_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_bzns_low_loyalty_decrease_effect = {
+	custom_effect_tooltip = BUL_bzns_tt
+	custom_effect_tooltip = BUL_low_loyalty_decrease_tt
+	add_to_variable = { BUL_bzns_loyalty = BUL_faction_low_decrease }
+	clamp_variable = {
+		var = BUL_bzns_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_bzns_low_popularity_decrease_effect = {
+	custom_effect_tooltip = BUL_bzns_tt
+	custom_effect_tooltip = BUL_low_popularity_decrease_tt
+	add_to_variable = { BUL_bzns_popularity = BUL_faction_low_decrease }
+	clamp_variable = {
+		var = BUL_bzns_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_bzns_medium_loyalty_decrease_effect = {
+	custom_effect_tooltip = BUL_bzns_tt
+	custom_effect_tooltip = BUL_medium_loyalty_decrease_tt
+	add_to_variable = { BUL_bzns_loyalty = BUL_faction_medium_decrease }
+	clamp_variable = {
+		var = BUL_bzns_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_bzns_medium_popularity_decrease_effect = {
+	custom_effect_tooltip = BUL_bzns_tt
+	custom_effect_tooltip = BUL_medium_popularity_decrease_tt
+	add_to_variable = { BUL_bzns_popularity = BUL_faction_medium_decrease }
+	clamp_variable = {
+		var = BUL_bzns_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_bzns_high_loyalty_decrease_effect = {
+	custom_effect_tooltip = BUL_bzns_tt
+	custom_effect_tooltip = BUL_high_loyalty_decrease_tt
+	add_to_variable = { BUL_bzns_loyalty = BUL_faction_high_decrease }
+	clamp_variable = {
+		var = BUL_bzns_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_bzns_high_popularity_decrease_effect = {
+	custom_effect_tooltip = BUL_bzns_tt
+	custom_effect_tooltip = BUL_high_popularity_decrease_tt
+	add_to_variable = { BUL_bzns_popularity = BUL_faction_high_decrease }
+	clamp_variable = {
+		var = BUL_bzns_popularity
+		min = 0
+		max = 100
+	}
+}
+
+#NATIONAL SOCIAL MOVEMENT
+BUL_nsm_low_loyalty_increase_effect = {
+	custom_effect_tooltip = BUL_nsm_tt
+	custom_effect_tooltip = BUL_low_loyalty_increase_tt
+	add_to_variable = { BUL_nsm_loyalty = BUL_faction_low_increase }
+	clamp_variable = {
+		var = BUL_nsm_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_nsm_low_popularity_increase_effect = {
+	custom_effect_tooltip = BUL_nsm_tt
+	custom_effect_tooltip = BUL_low_popularity_increase_tt
+	add_to_variable = { BUL_nsm_popularity = BUL_faction_low_increase }
+	clamp_variable = {
+		var = BUL_nsm_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_nsm_medium_loyalty_increase_effect = {
+	custom_effect_tooltip = BUL_nsm_tt
+	custom_effect_tooltip = BUL_medium_loyalty_increase_tt
+	add_to_variable = { BUL_nsm_loyalty = BUL_faction_medium_increase }
+	clamp_variable = {
+		var = BUL_nsm_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_nsm_medium_popularity_increase_effect = {
+	custom_effect_tooltip = BUL_nsm_tt
+	custom_effect_tooltip = BUL_medium_popularity_increase_tt
+	add_to_variable = { BUL_nsm_popularity = BUL_faction_medium_increase }
+	clamp_variable = {
+		var = BUL_nsm_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_nsm_high_loyalty_increase_effect = {
+	custom_effect_tooltip = BUL_nsm_tt
+	custom_effect_tooltip = BUL_high_loyalty_increase_tt
+	add_to_variable = { BUL_nsm_loyalty = BUL_faction_high_increase }
+	clamp_variable = {
+		var = BUL_nsm_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_nsm_high_popularity_increase_effect = {
+	custom_effect_tooltip = BUL_nsm_tt
+	custom_effect_tooltip = BUL_high_popularity_increase_tt
+	add_to_variable = { BUL_nsm_popularity = BUL_faction_high_increase }
+	clamp_variable = {
+		var = BUL_nsm_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_nsm_low_loyalty_decrease_effect = {
+	custom_effect_tooltip = BUL_nsm_tt
+	custom_effect_tooltip = BUL_low_loyalty_decrease_tt
+	add_to_variable = { BUL_nsm_loyalty = BUL_faction_low_decrease }
+	clamp_variable = {
+		var = BUL_nsm_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_nsm_low_popularity_decrease_effect = {
+	custom_effect_tooltip = BUL_nsm_tt
+	custom_effect_tooltip = BUL_low_popularity_decrease_tt
+	add_to_variable = { BUL_nsm_popularity = BUL_faction_low_decrease }
+	clamp_variable = {
+		var = BUL_nsm_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_nsm_medium_loyalty_decrease_effect = {
+	custom_effect_tooltip = BUL_nsm_tt
+	custom_effect_tooltip = BUL_medium_loyalty_decrease_tt
+	add_to_variable = { BUL_nsm_loyalty = BUL_faction_medium_decrease }
+	clamp_variable = {
+		var = BUL_nsm_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_nsm_medium_popularity_decrease_effect = {
+	custom_effect_tooltip = BUL_nsm_tt
+	custom_effect_tooltip = BUL_medium_popularity_decrease_tt
+	add_to_variable = { BUL_nsm_popularity = BUL_faction_medium_decrease }
+	clamp_variable = {
+		var = BUL_nsm_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_nsm_high_loyalty_decrease_effect = {
+	custom_effect_tooltip = BUL_nsm_tt
+	custom_effect_tooltip = BUL_high_loyalty_decrease_tt
+	add_to_variable = { BUL_nsm_loyalty = BUL_faction_high_decrease }
+	clamp_variable = {
+		var = BUL_nsm_loyalty
+		min = 0
+		max = 100
+	}
+}
+BUL_nsm_high_popularity_decrease_effect = {
+	custom_effect_tooltip = BUL_nsm_tt
+	custom_effect_tooltip = BUL_high_popularity_decrease_tt
+	add_to_variable = { BUL_nsm_popularity = BUL_faction_high_decrease }
+	clamp_variable = {
+		var = BUL_nsm_popularity
+		min = 0
+		max = 100
+	}
+}
+
+BUL_communists_try_to_form_ff_effect = {
+	set_variable = { BUL_ff_forming_probability = -100 } #The Fatherland Front can only be formed if this variable becomes greater than 0 during this check
+
+	if = { #Having war is relatively important
+		limit = {
+			has_war = yes
+		}
+		add_to_variable = { BUL_ff_forming_probability = 15 }
+		if = { #Having war against SOV is significant
+			limit = {
+				has_war_with = SOV
+				OR = {
+					NOT = { has_country_flag = BUL_at_war_with_the_soviets_flag }
+					has_country_flag = { flag = BUL_at_war_with_the_soviets_flag days > 180 }
+				}	
+			}
+			add_to_variable = { BUL_ff_forming_probability = 10 }
+			if = { #Having war against communist SOV is very important
+				limit = {
+					SOV = { has_government = communism }
+				}
+				add_to_variable = { BUL_ff_forming_probability = 50 }
+			}
+		}
+	}
+
+	if = { #An ally being at war with SOV is important
+		limit = {
+			any_allied_country = {
+				has_war_with = SOV
+			}
+		}
+		add_to_variable = { BUL_ff_forming_probability = 25 }
+		if = { #If SOV is communist then it becomes very important
+			limit = {
+				SOV = { has_government = communism }
+			}
+			add_to_variable = { BUL_ff_forming_probability = 75 }
+		}
+	}
+
+	if = { #Communist SOV controlling any neighbor state is relatively important
+		limit = {
+			any_neighbor_country = {
+				tag = SOV
+			}
+			SOV = { has_government = communism }
+		}
+		add_to_variable = { BUL_ff_forming_probability = 15 }
+		if= { #Neighbor SOV being at war with Bulgaria or her allies is critical
+			limit = {
+				OR = {
+					any_allied_country = {
+						has_war_with = SOV
+					}
+					has_war_with = SOV
+				}			
+			}
+			add_to_variable = { BUL_ff_forming_probability = 100 }
+		}
+	}
+
+	if = { #SOV being communist is relatively important
+		limit = {
+			SOV = { has_government = communism }
+		}
+		add_to_variable = { BUL_ff_forming_probability = 15 }
+	}
+
+	randomize_temp_variable = {
+		var = BUL_random_ff_forming_chance
+		distribution = binomial
+		min = 0
+		max = 100
+	}
+
+	if = {
+		limit = {
+			check_variable = {
+				var = BUL_ff_forming_probability
+				value = BUL_random_ff_forming_chance 
+				compare = greater_than_or_equals 
+			}
+		}
+		# SPTChange - Neutered Bulgarian Civil War
+		#country_event = { id = bftb_bulgaria_fatherland_front.1 hours = 16 random_hours = 16 }
+		country_event = { id = spt_bul.1 hours = 16 random_hours = 16 }
+	}
+	log = "Fatherland Front probability: [?BUL.BUL_ff_forming_probability]"
+	log = "Fatherland Front Random chance: [?BUL.BUL_random_ff_forming_chance]"
+}
+
+BUL_ff_approaches_a_faction_effect = {
+
+	randomize_variable = {
+		var = BUL_random_ff_approaching_faction_chance
+		distribution = binomial
+		min = 0
+		max = 100
+	}
+	log = "FF Approaches faction random chance: [?BUL.BUL_random_ff_approaching_faction_chance]"
+}
+
+BUL_ff_preventive_action_taken = {
+	add_to_variable = { BUL_ff_preventive_actions_against_coup = BUL_ff_preventive_actions_base_value }
+	clamp_variable = {
+		var = BUL_ff_preventive_actions_against_coup
+		min = 0
+		max = BUL_ff_preventive_actions_cap_value #This caps the player's ability to prevent the coup
+	}
+	custom_effect_tooltip = BUL_ff_preventive_action_taken_tt
+}
+
+BUL_ff_tries_to_stage_a_coup_effect = {
+	#Make sure the coup will start under the specific circumstances on historical
+	if = {
+		limit = {
+			is_historical_focus_on = yes
+			BUL_historical_requirements_met = yes
+		}
+		log = "Forced Fatherland Front coup"
+		country_event = { id = bftb_bulgaria_fatherland_front.2 hours = 4 random_hours = 4 }
+		set_country_flag = BUL_forced_ff_coup_flag
+	}
+	#If historical requirements not met, do a regular check
+	else = {
+		set_variable = { BUL_ff_coup_probability = -100 } #The coup will only happen if this variable becomes greater than 0 during this check
+
+		if = { #Having war is relatively important
+			limit = {
+				has_war = yes
+			}
+			add_to_variable = { BUL_ff_coup_probability = 15 }
+			if = { #Having war against SOV is significant
+				limit = {
+					has_war_with = SOV
+					OR = {
+						NOT = { has_country_flag = BUL_at_war_with_the_soviets_flag }
+						has_country_flag = { flag = BUL_at_war_with_the_soviets_flag days > 180 }
+					}
+				}
+				add_to_variable = { BUL_ff_coup_probability = 10 }
+				if = { #Having war against communist SOV is very important
+					limit = {
+						SOV = { has_government = communism }
+					}
+					add_to_variable = { BUL_ff_coup_probability = 40 } #Prev 50
+				}
+			}
+		}
+
+		if = { #An ally being at war with SOV is important
+			limit = {
+				any_allied_country = {
+					has_war_with = SOV
+				}
+			}
+			add_to_variable = { BUL_ff_coup_probability = 10 } #Prev 25
+			if = { #If SOV is communist then it becomes very important
+				limit = {
+					SOV = { has_government = communism }
+				}
+				add_to_variable = { BUL_ff_coup_probability = 15 } #Prev 75
+			}
+		}
+
+		if = { #Communist SOV controlling any neighbor state is relatively important
+			limit = {
+				any_neighbor_country = {
+					tag = SOV
+				}
+				has_government = communism
+			}
+			add_to_variable = { BUL_ff_coup_probability = 5 }
+			if = { #SOV controls one of our key states
+				limit = {
+					SOV = {
+						any_controlled_state = {
+							has_state_flag = BUL_initial_bulgarian_state_flag
+							is_in_home_area = yes
+						}
+					}
+				}
+				add_to_variable = { BUL_ff_coup_probability = 15 }
+				if= { #Neighbor SOV being at war with Bulgaria or her allies is critical
+					limit = {
+						OR = {
+							any_allied_country = {
+								has_war_with = SOV
+							}
+							has_war_with = SOV
+						}			
+					}
+					add_to_variable = { BUL_ff_coup_probability = 100 }
+				}
+			}
+		}
+
+		if = { #SOV conquering Germany
+			limit = {
+				SOV = {
+					any_controlled_state = {
+						is_core_of = GER
+					}
+				}
+			}
+			add_to_variable = { BUL_ff_coup_probability = 5 }
+			if = { #SOV conquering initial German states
+				limit = {
+					SOV = {
+						any_controlled_state = {
+							is_core_of = GER
+							NOT = {
+								state = 188
+								state = 763
+								state = 5
+								state = 807
+								state = 85
+							}
+						}
+					}
+				}
+				add_to_variable = { BUL_ff_coup_probability = 15 }
+			}
+		}
+
+		if = { #BUL losing key territory
+			limit = {
+				any_state = {
+					has_state_flag = BUL_initial_bulgarian_state_flag
+					controller = {
+						has_war_with = ROOT
+					}
+				}
+			}
+			add_to_variable = { BUL_ff_coup_probability = 15 }
+		}
+
+		if = { #SOV being communist is relatively important
+			limit = {
+				SOV = { has_government = communism }
+			}
+			add_to_variable = { BUL_ff_coup_probability = 10 } #Prev 15
+		}
+
+		randomize_temp_variable = {
+			var = BUL_random_ff_coup_chance
+			distribution = binomial
+			min = 0
+			max = 100
+		}
+
+		if = {
+			limit = {
+				check_variable = {
+					var = BUL_ff_coup_probability
+					value = BUL_random_ff_coup_chance 
+					compare = greater_than_or_equals 
+				}
+			}
+			country_event = { id = bftb_bulgaria_fatherland_front.2 hours = 4 random_hours = 4 }
+		}
+		log = "[GetDateText] - Fatherland Front coup probability: [?BUL.BUL_ff_coup_probability]"
+		log = "[GetDateText] - Fatherland Front coup Random chance: [?BUL.BUL_random_ff_coup_chance]"
+	}
+}
+
+BUL_start_ff_civil_war = {
+	set_variable = { BUL_communist_support_before_cw = party_popularity@communism }
+	set_variable = { BUL_ff_coup_size = 0.15 }
+	#Default state
+	if = {
+		limit = {
+			controls_state = 211
+		}
+		211 = { set_state_flag = BUL_ff_state_flag }
+	}
+	#Bonuses from BS
+	if = {
+		limit = {
+			has_country_flag = BUL_bs_joined_ff_flag 
+		}
+		add_to_variable = { BUL_ff_coup_size = 0.05 }
+		if = {
+			limit = {
+				NOT = { has_country_flag = BUL_bs_destroyed_flag }
+				NOT = { has_country_flag = BUL_bs_integrated_flag }
+			}
+			add_to_variable = { BUL_ff_coup_size = 0.05 }
+			212 = { set_state_flag = BUL_ff_state_flag }
+		}
+	}
+	#Bonuses from BZNS
+	if = {
+		limit = {
+			has_country_flag = BUL_bzns_joined_ff_flag 
+		}
+		add_to_variable = { BUL_ff_coup_size = 0.05 }
+		if = {
+			limit = {
+				NOT = { has_country_flag = BUL_bzns_destroyed_flag }
+				NOT = { has_country_flag = BUL_bzns_integrated_flag }
+			}
+			add_to_variable = { BUL_ff_coup_size = 0.05 }
+			801 = { set_state_flag = BUL_ff_state_flag } 
+		}
+	}
+	#Bonuses from Greek partisans
+	if = {
+		limit = {
+			has_country_flag = BUL_ff_organized_greek_partisans_flag
+		}
+		every_controlled_state = {
+			limit = {
+				is_core_of = GRE
+				is_core_of = BUL
+			}
+			set_state_flag = BUL_ff_state_flag
+		}
+		if = {
+			limit = {
+				NOT = { 
+					any_controlled_state = {
+						has_state_flag = BUL_ff_state_flag
+						is_core_of = GRE
+					}
+				}
+			}
+			random_controlled_state = {
+				limit = {
+					is_core_of = GRE
+				}
+				set_state_flag = BUL_ff_state_flag
+			}
+		}
+	}
+	#Bonuses from Yugoslavian partisans
+	if = {
+		limit = {
+			has_country_flag = BUL_ff_organized_yugoslavian_partisans_flag
+		}
+		every_controlled_state = {
+			limit = {
+				is_core_of = YUG
+				is_core_of = BUL
+				NOT = { state = 106 }
+			}
+			set_state_flag = BUL_ff_state_flag
+		}
+		if = {
+			limit = {
+				NOT = { 
+					any_controlled_state = {
+						is_core_of = YUG
+						has_state_flag = BUL_ff_state_flag
+					}
+				}
+			}
+			random_controlled_state = {
+				limit = {
+					is_core_of = YUG
+					NOT = { state = 106 }
+				}
+				set_state_flag = BUL_ff_state_flag
+			}
+		}
+	}
+	#Bonuses from ZVENO
+	if = {
+		limit = {
+			has_country_flag = BUL_zveno_joined_ff_flag 
+		}
+		add_to_variable = { BUL_ff_coup_size = 0.1 }
+		if = {
+			limit = {
+				NOT = { has_country_flag = BUL_zveno_destroyed_flag }
+				NOT = { has_country_flag = BUL_zveno_integrated_flag }
+			}
+			add_to_variable = { BUL_ff_coup_size = 0.25 }
+			48 = { set_state_flag = BUL_ff_state_flag } 
+			#Manage capital for original BUL
+			if = {
+				limit = {
+					any_owned_state = {
+						is_core_of = ROOT
+						NOT = { has_state_flag = BUL_ff_state_flag }
+					}
+				}
+				random_owned_state = {
+					limit = {
+						is_core_of = ROOT
+						NOT = { has_state_flag = BUL_ff_state_flag }
+					}
+					ROOT = { set_capital = { state = PREV } }
+				}
+			}
+			else = {
+				random_controlled_state = {
+					limit = {
+						NOT = { has_state_flag = BUL_ff_state_flag }
+					}
+					ROOT = { set_capital = { state = PREV } }
+				}
+			}
+		}
+	}
+
+	log = "Fatherland coup size: [?BUL.BUL_ff_coup_size]"
+
+	#Set FF capital based on the states they get in the split
+	if = {
+		limit = {
+			48 = { has_state_flag = BUL_ff_state_flag } #Sofia is FF's capital
+		}
+		#START CIVIL WAR
+		start_civil_war = {
+			ideology = communism
+			size = BUL_ff_coup_size
+			capital = 48
+			states = all
+			states_filter = {
+				has_state_flag = BUL_ff_state_flag
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			212 = { has_state_flag = BUL_ff_state_flag } #Plovdiv is FF's capital
+		}
+		#START CIVIL WAR
+		start_civil_war = {
+			ideology = communism
+			size = BUL_ff_coup_size
+			capital = 212
+			states = all
+			states_filter = {
+				has_state_flag = BUL_ff_state_flag
+			}
+		}
+	}
+	else = {	#Varna is FF's capital
+		#START CIVIL WAR
+		start_civil_war = {
+			ideology = communism
+			size = BUL_ff_coup_size
+			capital = 211
+			states = all
+			states_filter = {
+				has_state_flag = BUL_ff_state_flag
+			}
+		}
+	}
+
+	clr_country_flag = BUL_factions_unlocked_flag
+
+	random_country = {
+		limit = {
+			original_tag = BUL
+			has_government = communism
+			NOT = { has_country_flag = BUL_ff_civil_war_flag }
+		}
+		set_country_flag = BUL_fatherland_front_flag
+		set_cosmetic_tag = BUL_ff_bulgaria
+
+		division_template = {
+			name = "Fatherland Front Militia"
+			priority = 1
+			is_locked = yes
+			division_names_group = BUL_INF_04
+			regiments = {
+				infantry = { x = 0 y = 0 }
+				infantry = { x = 0 y = 1 }
+				infantry = { x = 0 y = 2 }
+			}
+		}
+
+		division_template = {
+			name = "Fatherland Front Partisans"
+			priority = 1
+			is_locked = yes
+			division_names_group = BUL_INF_06
+			regiments = {
+				infantry = { x = 0 y = 0 }
+				infantry = { x = 0 y = 1 }
+				infantry = { x = 0 y = 1 }
+			}
+		}
+
+		#Spawn FATHERLAND FRONT MILITIAS
+		#Cored states
+		every_owned_state = {
+			limit = {
+				OR = {
+					has_state_flag = BUL_initial_bulgarian_state_flag
+					state = 803 #Southern Serbia
+					state = 77 #Dobrudja
+				}
+			}
+			create_unit = {
+				division = "division_template = \"Fatherland Front Militia\" start_experience_factor = 0.25"  
+				owner = PREV
+			}
+		}
+		if = {
+			limit = {
+				check_variable = { BUL_communist_support_before_cw = 15 compare = greater_than_or_equals }
+			}
+			every_owned_state = {
+				limit = {
+					has_state_flag = BUL_initial_bulgarian_state_flag
+				}
+				create_unit = {
+					division = "division_template = \"Fatherland Front Militia\" start_experience_factor = 0.15"  
+					owner = PREV
+				}
+			}
+			if = {
+				limit = {
+					check_variable = { BUL_communist_support_before_cw = 30 compare = greater_than_or_equals }
+				}
+				every_owned_state = {
+					limit = {
+						has_state_flag = BUL_initial_bulgarian_state_flag
+					}
+					create_unit = {
+						division = "division_template = \"Fatherland Front Militia\" start_experience_factor = 0.1"  
+						owner = PREV
+					}
+				}
+			}
+		}
+		#Bonus from BS in the FF
+		if = {
+			limit = {
+				has_country_flag = BUL_bs_joined_ff_flag 
+				owns_state = 212
+			}
+			212 = {
+				create_unit = {
+					division = "division_template = \"Fatherland Front Militia\" start_experience_factor = 0.15"  
+					owner = PREV
+				}
+				create_unit = {
+					division = "division_template = \"Fatherland Front Militia\" start_experience_factor = 0.15"  
+					owner = PREV
+				}
+			}
+		}
+		#Bonus from BZNS in the FF
+		if = {
+			limit = {
+				has_country_flag = BUL_bs_joined_ff_flag 
+				owns_state = 801
+			}
+			801 = {
+				create_unit = {
+					division = "division_template = \"Fatherland Front Militia\" start_experience_factor = 0.1"  
+					owner = PREV
+				}
+				create_unit = {
+					division = "division_template = \"Fatherland Front Militia\" start_experience_factor = 0.1"  
+					owner = PREV
+				}
+			}
+		}
+
+		#Greek states
+		if = {
+			limit = { 
+				ROOT = { has_country_flag = BUL_ff_organized_greek_partisans_flag }
+			}
+			#Greek controlled states
+			every_owned_state = {
+				limit = {
+					has_state_flag = BUL_ff_state_flag
+					is_core_of = GRE
+				}
+				create_unit = {
+					division = "division_template = \"Fatherland Front Partisans\" start_experience_factor = 0.2" 
+					owner = PREV
+					count = 1
+				}
+			}
+			#Greek non-controlled states
+			random_state = {
+				limit = {
+					owner = { has_country_flag = BUL_ff_civil_war_flag }
+					is_core_of = GRE
+				}
+				create_unit = {
+					division = "division_template = \"Fatherland Front Partisans\" start_experience_factor = 0.4"
+					owner = PREV
+					allow_spawning_on_enemy_provs = yes
+					count = 2
+				}
+			}
+		}
+		
+		#Yugoslavian states
+		if = {
+			limit = { 
+				ROOT = { has_country_flag = BUL_ff_organized_yugoslavian_partisans_flag }
+			}
+			#Yugoslavian controlled states
+			every_owned_state = {
+				limit = {
+					has_state_flag = BUL_ff_state_flag
+					is_core_of = YUG
+				}
+				create_unit = {
+					division = "division_template = \"Fatherland Front Partisans\" start_experience_factor = 0.2" 
+					owner = PREV
+					count = 1
+				}
+			}
+			#Yugoslavian non-controlled states
+			random_state = {
+				limit = {
+					owner = { has_country_flag = BUL_ff_civil_war_flag }
+					is_core_of = YUG
+				}
+				create_unit = {
+					division = "division_template = \"Fatherland Front Partisans\" start_experience_factor = 0.4"
+					owner = PREV
+					allow_spawning_on_enemy_provs = yes
+					count = 2
+				}
+			}
+		}
+
+		#Generals
+		every_unit_leader = {
+			limit = {
+				NOT = { has_trait = trait_BUL_ff_sympathizer }
+			}
+			set_nationality = ROOT
+		}
+		ROOT = {
+			every_unit_leader = {
+				limit = {
+					has_trait = trait_BUL_ff_sympathizer
+				}
+				set_nationality = PREV.PREV
+			}
+		}
+		random_unit_leader = {
+			limit = {
+				has_id = 1203 #Hadzhipetkov
+			}
+			promote_leader = yes
+		}
+
+		#Operatives in the FF
+		if = {
+			limit = {
+				has_dlc = "La Resistance"
+			}
+			every_operative = {
+				limit = {
+					has_trait = trait_BUL_tsar_loyalist
+				}
+				set_nationality = BUL
+			}
+		}
+	}
+	#Operatives in original BUL
+	if = {
+		limit = {
+			has_dlc = "La Resistance"
+		}
+		every_operative = {
+			limit = {
+				has_trait = trait_BUL_ff_sympathizer
+			}
+			set_nationality = BUF
+		}
+		if = {
+			limit = {
+				has_country_flag = BUL_zveno_joined_ff_flag
+			}
+			every_operative = {
+				limit = {
+					has_trait = trait_BUL_zveno_member
+				}
+				set_nationality = BUF
+			}
+		}
+	}
+
+	#FF joins SOV's faction and wars and give Military Access
+	if = {
+		limit = {
+			country_exists = SOV
+			has_war_with = SOV
+			SOV = { has_government = communism }
+		}
+		if = {
+			limit = {
+				SOV = { is_in_faction = yes }
+			}
+			SOV = {
+				faction_leader = {
+					add_to_faction = BUF
+				}
+			}
+		}
+		if = {
+			limit = {
+				any_country = {
+					has_war_with = SOV
+					is_in_faction_with = BUL
+					NOT = {	has_country_flag = BUL_ff_civil_war_flag }
+				}
+			}
+			every_country = {
+				limit = {
+					has_war_with = SOV
+					is_in_faction_with = BUL
+					NOT = {	has_country_flag = BUL_ff_civil_war_flag }
+				}
+				BUF = {
+					add_to_war = { targeted_alliance = SOV enemy = PREV hostility_reason = asked_to_join }
+				}
+			}
+		}
+	}
+	diplomatic_relation = {
+		country = SOV
+		relation = military_access
+		active = yes
+	}
+	SOV = {
+		diplomatic_relation = {
+			country = BUF
+			relation = military_access
+			active = yes
+		}
+	}
+}
+
+BUL_get_random_bulgarian_destination_royal_visit = { #This works together with scripted loc
+	random_list = {
+		10 = {
+			modifier = {
+				factor = 0
+				48 = { is_capital = yes } #No point on visiting your own city...
+			}
+			set_variable = { BUL_tsars_destination = 1 } # Sofia
+		}
+		10 = {
+			set_variable = { BUL_tsars_destination = 2 } # Plovdiv
+		}
+		10 = {
+			set_variable = { BUL_tsars_destination = 3 } # Ruse
+		}
+		10 = {
+			set_variable = { BUL_tsars_destination = 4 } # Varna
+		}
+		10 = {
+			set_variable = { BUL_tsars_destination = 5 } # Burgas
+		}
+		10 = {
+			set_variable = { BUL_tsars_destination = 6 } # Vidin
+		}
+		10 = {
+			set_variable = { BUL_tsars_destination = 7 } # Tarnovo
+		}
+		10 = {
+			set_variable = { BUL_tsars_destination = 8 } # Stara Zagora
+		}
+		10 = {
+			set_variable = { BUL_tsars_destination = 9 } # Haskovo
+		}
+		10 = {
+			set_variable = { BUL_tsars_destination = 10 } # Shumen
+		}
+		10 = {
+			set_variable = { BUL_tsars_destination = 11 } # Sliven
+		}
+		10 = {
+			set_variable = { BUL_tsars_destination = 12 } # Yambol
+		}
+		10 = {
+			set_variable = { BUL_tsars_destination = 13 } # Pleven
+		}
+		10 = {
+			set_variable = { BUL_tsars_destination = 14 } # Dobrich
+			modifier = {
+				factor = 0
+				NOT = {
+					77 = {
+						is_owned_by = BUL
+						is_core_of = BUL
+					}
+				}
+			}
+		}
+		10 = {
+			set_variable = { BUL_tsars_destination = 15 } # Skopje
+			modifier = {
+				factor = 0
+				NOT = {
+					106 = {
+						is_owned_by = BUL
+						is_core_of = BUL
+					}
+				}
+			}
+		}
+		10 = {
+			set_variable = { BUL_tsars_destination = 16 } # Ohrid
+			modifier = {
+				factor = 0
+				NOT = {
+					106 = {
+						is_owned_by = BUL
+						is_core_of = BUL
+					}
+				}
+			}
+		}
+		10 = {
+			set_variable = { BUL_tsars_destination = 17 } # Leskovac
+			modifier = {
+				factor = 0
+				NOT = {
+					803 = {
+						is_owned_by = BUL
+						is_core_of = BUL
+					}
+				}
+			}
+		}
+	}
+}
+
+BUL_get_random_bulgarian_destination_march = { #This works together with scripted loc
+	random_list = {
+		10 = {
+			modifier = {
+				factor = 0
+				48 = { is_capital = yes } #No point on marching from Sofia to Sofia...
+			}
+			set_variable = { BUL_march_destination = 1 } # Sofia
+		}
+		10 = {
+			set_variable = { BUL_march_destination = 2 } # Plovdiv
+		}
+		10 = {
+			set_variable = { BUL_march_destination = 3 } # Ruse
+		}
+		10 = {
+			set_variable = { BUL_march_destination = 4 } # Varna
+		}
+		10 = {
+			set_variable = { BUL_march_destination = 5 } # Burgas
+		}
+		10 = {
+			set_variable = { BUL_march_destination = 6 } # Vidin
+		}
+		10 = {
+			set_variable = { BUL_march_destination = 7 } # Tarnovo
+		}
+		10 = {
+			set_variable = { BUL_march_destination = 8 } # Stara Zagora
+		}
+		10 = {
+			set_variable = { BUL_march_destination = 9 } # Haskovo
+		}
+		10 = {
+			set_variable = { BUL_march_destination = 10 } # Shumen
+		}
+		10 = {
+			set_variable = { BUL_march_destination = 11 } # Sliven
+		}
+		10 = {
+			set_variable = { BUL_march_destination = 12 } # Yambol
+		}
+		10 = {
+			set_variable = { BUL_march_destination = 13 } # Pleven
+		}
+		10 = {
+			set_variable = { BUL_march_destination = 14 } # Dobrich
+			modifier = {
+				factor = 0
+				NOT = {
+					77 = {
+						is_owned_by = BUL
+						is_core_of = BUL
+					}
+				}
+			}
+		}
+		10 = {
+			set_variable = { BUL_march_destination = 15 } # Skopje
+			modifier = {
+				factor = 0
+				NOT = {
+					106 = {
+						is_owned_by = BUL
+						is_core_of = BUL
+					}
+				}
+			}
+		}
+		10 = {
+			set_variable = { BUL_march_destination = 16 } # Ohrid
+			modifier = {
+				factor = 0
+				NOT = {
+					106 = {
+						is_owned_by = BUL
+						is_core_of = BUL
+					}
+				}
+			}
+		}
+		10 = {
+			set_variable = { BUL_march_destination = 17 } # Leskovac
+			modifier = {
+				factor = 0
+				NOT = {
+					803 = {
+						is_owned_by = BUL
+						is_core_of = BUL
+					}
+				}
+			}
+		}
+	}
+}
+
+BUL_replace_national_industrial_designer = {
+	if = {
+		limit = {
+			has_idea =  BUL_petrol_ad
+		}
+		swap_ideas = {
+			remove_idea = BUL_petrol_ad
+			add_idea = BUL_petrol_ad_improved
+		}
+	}
+	else_if = {
+		limit = {
+			has_idea = BUL_ira
+		}
+		swap_ideas = {
+			remove_idea = BUL_ira
+			add_idea = BUL_ira_improved
+		}
+	}
+	else_if = {
+		limit = {
+			has_idea = BUL_pirin
+		}
+		swap_ideas = {
+			remove_idea = BUL_pirin
+			add_idea = BUL_pirin_improved
+		}
+	}
+	else_if = {
+		limit = {
+			has_idea = BUL_vulkan_cement
+		}
+		swap_ideas = {
+			remove_idea = BUL_vulkan_cement
+			add_idea = BUL_vulkan_cement_improved
+		}
+	}	
+}
+
+BUL_replace_national_naval_designer = {
+	if = {
+		limit = {
+			has_idea = BUL_varna_naval_dockyard
+		}
+		custom_effect_tooltip = BUL_replace_national_naval_designer_tt
+		hidden_effect = {
+			swap_ideas = {
+				remove_idea = BUL_varna_naval_dockyard
+				add_idea = BUL_varna_naval_dockyard_improved
+			}
+		}
+	}
+	else = {
+		custom_effect_tooltip = BUL_replace_national_naval_designer_tt
+	}
+}
+
+BUL_replace_national_aircraft_designer = {
+	if = {
+		limit = {
+			has_idea = BUL_dar
+		}
+		swap_ideas = {
+			remove_idea = BUL_dar
+			add_idea = BUL_dar_improved
+		}
+	}
+	if = {
+		limit = {
+			has_idea = BUL_kaproni_bulgarski
+		}
+		swap_ideas = {
+			remove_idea = BUL_kaproni_bulgarski
+			add_idea = BUL_kaproni_bulgarski_improved
+		}
+	}
+	if = {
+		limit = {
+			has_idea = BUL_dvf
+		}
+		swap_ideas = {
+			remove_idea = BUL_dvf
+			add_idea = BUL_dvf_improved
+		}
+	}
+	if = {
+		limit = {
+			has_idea = BUL_dvf_sopot
+		}
+		swap_ideas = {
+			remove_idea = BUL_dvf_sopot
+			add_idea = BUL_dvf_sopot_improved
+		}
+	}
+}
+
+BUL_set_buz_faction_values = {
+	set_country_flag = BUL_factions_unlocked_flag
+	set_variable = { BUL_zveno_loyalty = 15 }
+	set_variable = { BUL_zveno_popularity = 50 }
+	set_variable = { BUL_bs_loyalty = 25 }
+	set_variable = { BUL_bs_popularity = 60 }
+	set_variable = { BUL_bzns_loyalty = 30 }
+	set_variable = { BUL_bzns_popularity = 70 }
+	set_variable = { BUL_nsm_loyalty = 60 }
+	set_variable = { BUL_nsm_popularity = 40 }
+	set_variable = { BUL_faction_interaction_cost_standard = 20 }
+	set_variable = { BUL_broad_socialist_opression_cost_standard = 20 }
+	set_variable = { BUL_faction_days_remove_very_low = 7 } #Allow Speech, Discredit, Repress
+	set_variable = { BUL_faction_days_remove_low = 14 } #Joint Act, Ban Media, Anti-faction Speech
+	set_variable = { BUL_faction_days_remove_medium = 21 } #Bolster Zveno, Imprison leaders
+	set_variable = { BUL_faction_days_remove_high = 30 } #Legalize, Fund, Appoint, Raid, Destroy
+	set_variable = { BUL_faction_days_remove_very_high = 60 } #Integrate
+	set_variable = { BUL_faction_days_reenable_low = 7 } #Allow Speech, Discredit
+	set_variable = { BUL_faction_days_reenable_medium = 14 } #Joint Act, Anti-faction Speech
+	set_variable = { BUL_faction_days_reenable_high = 60 } #Fund
+	set_variable = { BUL_faction_days_reenable_very_high = 120 } #Raid
+	set_variable = { BUL_faction_low_increase = 5 }
+	set_variable = { BUL_faction_medium_increase = 10 }
+	set_variable = { BUL_faction_high_increase = 15 }
+	set_variable = { BUL_faction_low_decrease = -5 }
+	set_variable = { BUL_faction_medium_decrease = -10 }
+	set_variable = { BUL_faction_high_decrease = -15 }
+	set_variable = { BUL_ff_missions_base_days_to_add = 60 } #Base amount of days to be added to Impending FF Coup mission
+	set_variable = { BUL_ff_missions_popularity_factor = 1 } #More popularity means more days to add
+	set_variable = { BUL_ff_missions_loyalty_factor = 1 } #More loyalty means less days to add
+	set_variable = { BUL_ff_preventive_actions_against_coup = 0 } #This will be used to reduce the chances of the FF staging the coup after they have planned it
+	set_variable = { BUL_ff_preventive_actions_base_value = 5 } #The value added to the variable above every time a decision to prevent the coup is taken
+	set_variable = { BUL_ff_preventive_actions_cap_value = 50 } #This is a cap to the player's ability to prevent the coup
+	set_variable = { BUL_purchase_equipment_cost = 25 }
+	set_variable = { BUL_foreign_military_agreements_cost = 50 }
+	set_variable = { BUL_german_civ_industries_cost = 75 }
+	set_variable = { BUL_british_civ_industries_cost = 75 }
+	set_variable = { BUL_soviet_civ_industries_cost = 75 }
+	set_variable = { BUL_foreign_industry_consumer_goods_modifier = 0 } #Used by Foreign Industry Dynamic Modifier
+	set_variable = { BUL_foreign_industry_production_efficiency_modifier = -0.05 } #Used by Foreign Industry Dynamic Modifier
+	set_variable = { BUL_foreign_industry_construction_speed_modifier = -0.1 } #Used by Foreign Industry Dynamic Modifier
+	set_variable = { BUL_german_industrial_investments = 0 }
+	set_variable = { BUL_british_industrial_investments = 0 }
+	set_variable = { BUL_soviet_industrial_investments = 0 }
+	set_variable = { BUL_industrial_investments_basic_cap = 3 }
+	set_variable = { BUL_industrial_investments_medium_cap = 5 }
+	set_variable = { BUL_industrial_investments_max_cap = 10 }
+	#IMRO
+	set_variable = { BUL_imro_garrisons_mp_value = 5000 }
+	#Purchase foreign equipment
+	set_variable = { BUL_quantity_purchased_infantry_equipment = 1000 }
+	set_variable = { BUL_quantity_purchased_artillery = 100 }
+	set_variable = { BUL_quantity_purchased_motorized = 100 }
+	set_variable = { BUL_quantity_purchased_mechanized = 50 }
+	set_variable = { BUL_quantity_purchased_armored_car = 50 }
+	set_variable = { BUL_quantity_purchased_light_armor = 40 }
+	set_variable = { BUL_quantity_purchased_medium_armor = 20 }
+	set_variable = { BUL_quantity_purchased_heavy_armor = 10 }
+	set_variable = { BUL_quantity_purchased_fighter = 40 }
+	set_variable = { BUL_quantity_purchased_naval_bomber = 30 }
+	set_variable = { BUL_quantity_purchased_tactical_bomber = 20 }
+	#Plot Against Boris
+	set_variable = { BUL_regicide_execution_time = 90 }
+	#Free Balkan States dynamic modifier (NS)
+	set_variable = { BUL_our_duty_in_the_balkans_consumer_goods_modifier = -0.03 }
+	set_variable = { BUL_our_duty_in_the_balkans_stability_modifier = 0.05 }
+	#Monthly extra chance of Boris dieing of "natural causes" (increased by 5 each month from 1943.1.1)
+	set_variable = { BUL_tsar_boris_death_monthly_probability_factor = 0 }
+
+	randomize_variable = {
+		var = BUL_tsars_destination
+		distribution = uniform
+		min = 2
+		max = 13
+	}
+	round_variable = BUL_tsars_destination
+	randomize_variable = {
+		var = BUL_march_destination
+		distribution = uniform
+		min = 2
+		max = 13
+	}
+	round_variable = BUL_march_destination
+}
+
+#Adds hidden NS granting attack & defense bonuses against the appropriate country (FROM - scope comes from "The Anti-Capitalist Fight" or "Toppling Giants" Focus)
+BUL_add_hidden_targeted_ns = {
+	if = {
+		limit = {
+			original_tag = ENG
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_eng
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = FRA
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_fra
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = GER
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_ger
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = ITA
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_ita
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = SOV
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_sov
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = POR
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_por
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = SPR
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_spr
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = IRE
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_ire
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = HOL
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_hol
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = BEL
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_bel
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = LUX
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_lux
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = SWI
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_swi
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = AUS
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_aus
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = CZE
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_cze
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = HUN
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_hun
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = YUG
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_yug
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = ALB
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_alb
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = GRE
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_gre
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = TUR
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_tur
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = ROM
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_rom
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = POL
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_pol
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = EST
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_est
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = LAT
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_lat
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = LIT
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_lit
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = SWE
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_swe
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = FIN
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_fin
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = NOR
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_nor
+		}
+	}
+	else_if = {
+		limit = {
+			original_tag = DEN
+		}
+		ROOT = {
+			add_ideas = BUL_anti_capitalism_den
+		}
+	}
+}
+
+BUL_add_improved_prussia_of_the_balkans_ns = {
+	if = {
+		limit = {
+			has_idea = BUL_prussia_of_the_balkans_01
+		}
+		swap_ideas = {
+			remove_idea = BUL_prussia_of_the_balkans_01
+			add_idea = BUL_prussia_of_the_balkans_02
+		}
+	}
+	else_if = {
+		limit = {
+			has_idea = BUL_prussia_of_the_balkans_02
+		}
+		swap_ideas = {
+			remove_idea = BUL_prussia_of_the_balkans_02
+			add_idea = BUL_prussia_of_the_balkans_03
+		}
+	}
+	else_if = {
+		limit = {
+			has_idea = BUL_prussia_of_the_balkans_03
+		}
+		swap_ideas = {
+			remove_idea = BUL_prussia_of_the_balkans_03
+			add_idea = BUL_prussia_of_the_balkans_04
+		}
+	}
+	else_if = {
+		limit = {
+			has_idea = BUL_prussia_of_the_balkans_weakened_01
+		}
+		swap_ideas = {
+			remove_idea = BUL_prussia_of_the_balkans_weakened_01
+			add_idea = BUL_prussia_of_the_balkans_01
+		}
+	}
+	else_if = {
+		limit = {
+			has_idea = BUL_prussia_of_the_balkans_weakened_02
+		}
+		swap_ideas = {
+			remove_idea = BUL_prussia_of_the_balkans_weakened_02
+			add_idea = BUL_prussia_of_the_balkans_weakened_01
+		}
+	}
+	else_if = {
+		limit = {
+			has_idea = BUL_prussia_of_the_balkans_weakened_03
+		}
+		swap_ideas = {
+			remove_idea = BUL_prussia_of_the_balkans_weakened_03
+			add_idea = BUL_prussia_of_the_balkans_02
+		}
+	}
+}
+
+BUL_add_weakened_prussia_of_the_balkans_ns = {
+	if = {
+		limit = {
+			has_idea = BUL_prussia_of_the_balkans_01
+		}
+		swap_ideas = {
+			remove_idea = BUL_prussia_of_the_balkans_01
+			add_idea = BUL_prussia_of_the_balkans_weakened_01
+		}
+	}
+	else_if = {
+		limit = {
+			has_idea = BUL_prussia_of_the_balkans_02
+		}
+		swap_ideas = {
+			remove_idea = BUL_prussia_of_the_balkans_02
+			add_idea = BUL_prussia_of_the_balkans_01
+		}
+	}
+	else_if = {
+		limit = {
+			has_idea = BUL_prussia_of_the_balkans_03
+		}
+		swap_ideas = {
+			remove_idea = BUL_prussia_of_the_balkans_03
+			add_idea = BUL_prussia_of_the_balkans_02
+		}
+	}
+	else_if = {
+		limit = {
+			has_idea = BUL_prussia_of_the_balkans_weakened_01
+		}
+		swap_ideas = {
+			remove_idea = BUL_prussia_of_the_balkans_weakened_01
+			add_idea = BUL_prussia_of_the_balkans_weakened_02
+		}
+	}
+	else_if = {
+		limit = {
+			has_idea = BUL_prussia_of_the_balkans_weakened_02
+		}
+		swap_ideas = {
+			remove_idea = BUL_prussia_of_the_balkans_weakened_02
+			add_idea = BUL_prussia_of_the_balkans_weakened_03
+		}
+	}
+}
+
+BUL_tsar_boris_may_die_effect = {
+	set_variable = { BUL_tsar_boris_death_probability = -100 } #Boris may die only if this variable becomes greater than 0 during this check
+
+	if = { #Having war against a major is relatively important
+		limit = {
+			any_enemy_country = {
+				is_major = yes
+			}
+		}
+		add_to_variable = { BUL_tsar_boris_death_probability = 15 }
+		if = { #Having war against main majors is significant
+			limit = {
+				OR = {
+					has_war_with = SOV
+					has_war_with = GER
+					has_war_with = ENG
+				}
+			}
+			add_to_variable = { BUL_tsar_boris_death_probability = 10 }
+		}
+	}
+
+	if = { #An ally being at war with SOV while BUL is not is important
+		limit = {
+			any_allied_country = {
+				has_war_with = SOV
+			}
+			BUL = { NOT = { has_war_with = SOV } }
+		}
+		add_to_variable = { BUL_tsar_boris_death_probability = 25 }
+	}
+
+	if = { #Faction leader having different ideology is important
+		limit = {
+			any_allied_country = {
+				is_faction_leader = yes
+				NOT = { has_government = ROOT }
+			}
+		}
+		add_to_variable = { BUL_tsar_boris_death_probability = 25 }
+	}
+
+	if = { #Low Non-Aligned support is important
+		limit = {
+			neutrality < 0.1
+		}
+		add_to_variable = { BUL_tsar_boris_death_probability = 25 }
+	}
+	else_if = {
+		limit = {
+			neutrality < 0.25
+		}
+		add_to_variable = { BUL_tsar_boris_death_probability = 20 }
+	}
+	else_if = {
+		limit = {
+			neutrality < 0.5
+		}
+		add_to_variable = { BUL_tsar_boris_death_probability = 15 }
+	}
+
+	if = { #Low Stability support is important
+		limit = {
+			has_stability < 0.1
+		}
+		add_to_variable = { BUL_tsar_boris_death_probability = 50 }
+	}
+	else_if = {
+		limit = {
+			has_stability < 0.25
+		}
+		add_to_variable = { BUL_tsar_boris_death_probability = 35 }
+	}
+	else_if = {
+		limit = {
+			has_stability < 0.5
+		}
+		add_to_variable = { BUL_tsar_boris_death_probability = 25 }
+	}
+
+	add_to_variable = { BUL_tsar_boris_death_probability = BUL_tsar_boris_death_monthly_probability_factor }
+
+	randomize_temp_variable = {
+		var = BUL_random_tsar_boris_death_chance
+		distribution = binomial
+		min = 0
+		max = 100
+	}
+
+	if = {
+		limit = {
+			check_variable = {
+				var = BUL_tsar_boris_death_probability
+				value = BUL_random_tsar_boris_death_chance 
+				compare = greater_than_or_equals 
+			}
+		}
+		country_event = { id = bftb_bulgaria_tsar_boris.2 days = 15 random_days = 13 }
+	}
+
+	add_to_variable = { BUL_tsar_boris_death_monthly_probability_factor = 5 } #Increase 5% each month.
+}
+
+BUL_halve_faction_management_decision_times = {
+	divide_variable = { BUL_faction_days_remove_very_low = 2 }
+	round_variable = BUL_faction_days_remove_very_low
+	divide_variable = { BUL_faction_days_remove_low = 2 }
+	round_variable = BUL_faction_days_remove_low
+	divide_variable = { BUL_faction_days_remove_medium = 2 }
+	round_variable = BUL_faction_days_remove_medium
+	divide_variable = { BUL_faction_days_remove_high = 2 }
+	round_variable = BUL_faction_days_remove_high
+	divide_variable = { BUL_faction_days_remove_very_high = 2 }
+	round_variable = BUL_faction_days_remove_very_high
+	divide_variable = { BUL_faction_days_reenable_low = 2 }
+	round_variable = BUL_faction_days_reenable_low
+	divide_variable = { BUL_faction_days_reenable_medium = 2 }
+	round_variable = BUL_faction_days_reenable_medium
+	divide_variable = { BUL_faction_days_reenable_high = 2 }
+	round_variable = BUL_faction_days_reenable_high
+	divide_variable = { BUL_faction_days_reenable_very_high = 2 }
+	round_variable = BUL_faction_days_reenable_very_high
+}
+
+BUL_join_wars_of_from = {
+	hidden_effect = {
+		every_other_country = {
+			limit = {
+				has_war_with = FROM
+				NOT = { is_in_faction_with = ROOT }
+			}
+			ROOT = {
+				add_to_war = {
+					targeted_alliance = FROM
+					enemy = PREV
+					hostility_reason = asked_to_join
+				}
+			}
+		}
+	}
+}
+
+BUL_remove_balkan_opinion_modifiers = { #Requires scoping to the other country joining Bulgaria's faction or being puppeted by Bulgaria
+	hidden_effect = {
+		remove_opinion_modifier = {
+			target = BUL
+			modifier = BFTB_balkan_pact_enemy
+		}
+		remove_opinion_modifier = {
+			target = BUL
+			modifier = BFTB_incongruous_neighbors
+		}
+		BUL = {
+			remove_opinion_modifier = {
+				target = PREV
+				modifier = BFTB_incongruous_neighbors
+			}
+		}
+	}
+}
+
+#Apply appropriate cosmetic tag so that 3D models change based on ideology
+BUL_set_appropriate_cosmetic_tag = {
+	if = {
+		limit = { original_tag = BUL }
+		if = {
+			limit = { has_country_flag = BUL_tbe_flag }
+			if = {
+				limit = { has_government = communism }
+				set_cosmetic_tag = TBE_third_bulgarian_empire_communism
+			}
+			else_if = {
+				limit = { has_government = democratic }
+				set_cosmetic_tag = TBE_third_bulgarian_empire_democratic
+			}
+			else_if = {
+				limit = { has_government = fascism }
+				set_cosmetic_tag = TBE_third_bulgarian_empire_fascism
+			}
+			else = {
+				set_cosmetic_tag = TBE_third_bulgarian_empire_neutrality
+			}
+		}
+		else_if = {
+			limit = { has_country_flag = BUL_ubf_flag }
+			if = {
+				limit = { has_government = communism }
+				set_cosmetic_tag = UBF_united_balkan_federation_communism
+			}
+			else_if = {
+				limit = { has_government = democratic }
+				set_cosmetic_tag = UBF_united_balkan_federation_democratic
+			}
+			else_if = {
+				limit = { has_government = fascism }
+				set_cosmetic_tag = UBF_united_balkan_federation_fascism
+			}
+			else = {
+				set_cosmetic_tag = UBF_united_balkan_federation_neutrality
+			}
+		}
+	}
+}

--- a/events/SPT_BUL.txt
+++ b/events/SPT_BUL.txt
@@ -1,0 +1,44 @@
+add_namespace = spt_bul
+
+country_event = { # Neutered Bulgarian Civil war
+	id = spt_bul.1
+	title = spt_bul.1.t
+	desc = spt_bul.1.desc
+	
+	picture = GFX_report_event_sanation_revolt
+	
+	is_triggered_only = yes
+
+	fire_only_once = yes
+
+	immediate = {
+		hidden_effect = {
+			add_popularity = {
+				ideology = communism
+				popularity = 0.2
+			}
+			set_country_flag = BUL_fatherland_front_formed_flag
+		}
+	}
+
+	option = {
+		name = spt_bul.1.a
+		
+		effect_tooltip = {
+			add_popularity = {
+				ideology = communism
+				popularity = 0.2
+			}
+		}
+		set_party_name = {
+			ideology = communism
+			long_name = BUL_fatherland_front_party_long
+			name = BUL_fatherland_front_party
+		}
+		
+		add_timed_idea = {
+			idea = SPT_BUL_communist_party
+			days = 180
+		}
+	}
+}

--- a/localisation/english/spt_events_l_english.yml
+++ b/localisation/english/spt_events_l_english.yml
@@ -249,5 +249,5 @@ spt_mex.4.desc:0 "After another civil war erupted in mexico, people have lost al
 spt_mex.4.a:0 "§GPi pi pi pi pi pi pi pi pi pi...§!"
 
 spt_bul.1.t:0 "The Fatherland Front throws a Communist Party!"
-spt_bul.1.desc:0 "After the recent declaration of war on the Soviet Union, the Communist elements of the country have decided to unite in an effort to support their Russian Comrades.\n\nFortunately for us, after they received their orders from the Kremlin, a mistranslation of the word \"Coup\" for \"Cope\" made them decide to throw a party instead, to promote the communist ideology in the country."
+spt_bul.1.desc:0 "After the recent declaration of war on the Soviet Union, the nation's Communist factions resolved to unite in support of their Russian comrades.\n\nFortunately for us, when they received their orders from the Kremlin, a mistranslation turned the word \"Coup\" into \"Cope\". Believing it a directive, they chose to throw a party instead—celebrating and promoting communist ideology with music and drink, rather than with force."
 spt_bul.1.a:0 "Nazdrave!"

--- a/localisation/english/spt_events_l_english.yml
+++ b/localisation/english/spt_events_l_english.yml
@@ -247,3 +247,7 @@ spt_mex.3.a:0 "¡Viva México Unido!"
 spt_mex.4.t:0 "The second mexican civil war"
 spt_mex.4.desc:0 "After another civil war erupted in mexico, people have lost all faith in a stable government. This new conflict is already the third civil war of the decade.\n\nWith so many conflicts in the mexican countryside, the people are putting into question if their politicians truly know how to read."
 spt_mex.4.a:0 "§GPi pi pi pi pi pi pi pi pi pi...§!"
+
+spt_bul.1.t:0 "The Fatherland Front throws a Communist Party!"
+spt_bul.1.desc:0 "After the recent declaration of war on the Soviet Union, the Communist elements of the country have decided to unite in an effort to support their Russian Comrades.\n\nFortunately for us, after they received their orders from the Kremlin, a mistranslation of the word \"Coup\" for \"Cope\" made them decide to throw a party instead, to promote the communist ideology in the country."
+spt_bul.1.a:0 "Nazdrave!"

--- a/localisation/english/spt_ideas_l_english.yml
+++ b/localisation/english/spt_ideas_l_english.yml
@@ -265,3 +265,6 @@ SPT_scw_thunderdome_tier_2:0 "The Spanish Civil Thunderdome"
 SPT_scw_thunderdome_tier_2_desc:0 "Used for a meme game. ALL SPT RULES STILL APPLY. DO NOT ABUSE TO SEND VOLUNTEERS TO CHINA. VOLUNTEERS WILL BE PROSECUTED."
 SPT_scw_thunderdome_tier_fascist:0 "The Spanish Civil Thunderdome"
 SPT_scw_thunderdome_tier_fascist_desc:0 "Used for a meme game. ALL SPT RULES STILL APPLY. DO NOT ABUSE TO SEND VOLUNTEERS TO CHINA. VOLUNTEERS WILL BE PROSECUTED."
+
+SPT_BUL_communist_party:0 "The Bulgarian Communist Party"
+SPT_BUL_communist_party_desc:0 "The Communists are partying hard in Bulgaria"


### PR DESCRIPTION
Removed the Zveno Civil war entirely. Reworked the fatherland front to instead provide the midlevel National Spirit for 180 days with flavor text. This should still be stronger overall to all bulgarian builds. Zvno coup didn't trigger all the way to june 1941 in test builds and the correct Bulgarian fatherland front event succesfully triggered on test builds.